### PR TITLE
Fix kernel examples.

### DIFF
--- a/examples/ManagedExamples/KernelTrace001.cs
+++ b/examples/ManagedExamples/KernelTrace001.cs
@@ -33,6 +33,9 @@ namespace ManagedExamples
             // providers do.
             processProvider.OnEvent += (record) =>
             {
+                // We consult against the opcode for kernel providers.
+                // The opcodes are documented here:
+                // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364083(v=vs.85).aspx
                 if (record.Opcode == 0x01)
                 {
                     var image = record.GetAnsiString("ImageFileName", "Unknown");

--- a/examples/NativeExamples/kernel_and_user_trace_001.cpp
+++ b/examples/NativeExamples/kernel_and_user_trace_001.cpp
@@ -97,8 +97,9 @@ void setup_image_load_provider(krabs::kernel::image_load_provider& provider)
     provider.add_on_event_callback([](const EVENT_RECORD &record) {
         krabs::schema schema(record);
 
-        std::wstring event_name = schema.event_name();
-        if (event_name == L"Load") {
+        // Opcodes can be found on the kernel provider's documentation:
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364068(v=vs.85).aspx
+        if (schema.event_opcode() == 10) {
             krabs::parser parser(schema);
             std::wstring filename = parser.parse<std::wstring>(L"FileName");
             std::wcout << L"Loaded image from file " << filename << std::endl;

--- a/examples/NativeExamples/kernel_trace_001.cpp
+++ b/examples/NativeExamples/kernel_trace_001.cpp
@@ -25,8 +25,13 @@ void kernel_trace_001::start()
     provider.add_on_event_callback([](const EVENT_RECORD &record) {
         krabs::schema schema(record);
 
-        std::wstring event_name = schema.event_name();
-        if (event_name == L"Load") {
+        // To filter our events, we want to compare against the
+        // event opcode. For kernel traces, you can consult this page
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364083(v=vs.85).aspx
+        //
+        // The documentation specific to the image load provider is here:
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364068(v=vs.85).aspx
+        if (schema.event_opcode() == 10) {
             krabs::parser parser(schema);
             std::wstring filename = parser.parse<std::wstring>(L"FileName");
             std::wcout << L"Loaded image from file " << filename << std::endl;


### PR DESCRIPTION
Check against opcodes instead of event names in kernel examples. Event names seem to be inconsistently set.