### PR TITLE
Ensure that comparers.hpp is compiled as unmanaged code.

### DIFF
--- a/krabs/krabs/filtering/comparers.hpp
+++ b/krabs/krabs/filtering/comparers.hpp
@@ -14,6 +14,9 @@
 
 #if(_MANAGED)
 #pragma warning(pop)
+
+// Turn off managed compilation for this file.
+#pragma managed(push, off)
 #endif
 
 namespace krabs { namespace predicates {
@@ -133,3 +136,7 @@ namespace krabs { namespace predicates {
     } /* namespace comparers */
 
 } /* namespace predicates */ } /* namespace krabs */
+
+#if(_MANAGED)
+#pragma managed(pop)
+#endif

--- a/krabs/krabs/filtering/predicates.hpp
+++ b/krabs/krabs/filtering/predicates.hpp
@@ -7,7 +7,6 @@
 #include <functional>
 #include <algorithm>
 #include <string>
-#include <boost/algorithm/string.hpp>
 
 #include "../compiler_check.hpp"
 #include "comparers.hpp"

--- a/krabs/krabs/schema_locator.hpp
+++ b/krabs/krabs/schema_locator.hpp
@@ -31,11 +31,13 @@ namespace krabs {
         uint16_t  id;
         uint8_t   opcode;
         uint8_t   version;
+        uint8_t   level;
 
         schema_key(const EVENT_RECORD& record)
             : provider(record.EventHeader.ProviderId)
             , id(record.EventHeader.EventDescriptor.Id)
             , opcode(record.EventHeader.EventDescriptor.Opcode)
+            , level(record.EventHeader.EventDescriptor.Level)
             , version(record.EventHeader.EventDescriptor.Version) { }
 
         bool operator==(const schema_key& rhs) const
@@ -43,6 +45,7 @@ namespace krabs {
             return provider == rhs.provider &&
                    id == rhs.id &&
                    opcode == rhs.opcode &&
+                   level == rhs.level &&
                    version == rhs.version;
         }
 

--- a/krabs/krabs/schema_locator.hpp
+++ b/krabs/krabs/schema_locator.hpp
@@ -29,17 +29,20 @@ namespace krabs {
     {
         guid      provider;
         uint16_t  id;
+        uint8_t   opcode;
         uint8_t   version;
 
         schema_key(const EVENT_RECORD& record)
             : provider(record.EventHeader.ProviderId)
             , id(record.EventHeader.EventDescriptor.Id)
+            , opcode(record.EventHeader.EventDescriptor.Opcode)
             , version(record.EventHeader.EventDescriptor.Version) { }
 
         bool operator==(const schema_key& rhs) const
         {
             return provider == rhs.provider &&
                    id == rhs.id &&
+                   opcode == rhs.opcode &&
                    version == rhs.version;
         }
 


### PR DESCRIPTION
Ensure that comparers.hpp is compiled as unmanaged when /clr is set. This is necessary to ensure that when boost::* makes use of the std::locale lock, we only take the lock on the native side. If the std::locale lock is taken on the managed side, we introduce a loader lock.

Signed-off-by: Zac Brown (ODSP SECURITY) <zbrown@microsoft.com>