### PR TITLE
Improve property parsing

### DIFF
--- a/krabs/krabs/parser.hpp
+++ b/krabs/krabs/parser.hpp
@@ -179,13 +179,15 @@ namespace krabs {
             property_info propInfo(pBufferIndex_, currentPropInfo, propertyLength);
             cache_property(pName, propInfo);
 
+            // advance the buffer index since we've already processed this property
+            pBufferIndex_ += propertyLength;
+
             // The property was found, return it
             if (name == pName) {
+                // advance the index since we've already processed this property
+                ++i;
                 return propInfo;
             }
-
-            // Not found yet, advance the buffer index and try again
-            pBufferIndex_ += propertyLength;
         }
 
         // property wasn't found, return an empty propInfo

--- a/krabs/krabs/size_provider.hpp
+++ b/krabs/krabs/size_provider.hpp
@@ -117,8 +117,8 @@ namespace krabs {
         {
             if (propertyInfo.nonStructType.InType == TDH_INTYPE_UNICODESTRING)
             {
-                const wchar_t* p = (const wchar_t*)propertyStart;
-                const wchar_t* pEnd = (const wchar_t*)pRecordEnd;
+                auto p = (const wchar_t*)propertyStart;
+                auto pEnd = (const wchar_t*)pRecordEnd;
                 while (p < pEnd) {
                     if (!*p++) {
                         break;
@@ -128,8 +128,8 @@ namespace krabs {
             }
             else if (propertyInfo.nonStructType.InType == TDH_INTYPE_ANSISTRING)
             {
-                const char* p = (const char*)propertyStart;
-                const char* pEnd = (const char*)pRecordEnd;
+                auto p = (const char*)propertyStart;
+                auto pEnd = (const char*)pRecordEnd;
                 while (p < pEnd) {
                     if (!*p++) {
                         break;

--- a/krabs/krabs/testing/record_builder.hpp
+++ b/krabs/krabs/testing/record_builder.hpp
@@ -80,7 +80,8 @@ namespace krabs { namespace testing {
             const krabs::guid &providerId,
             size_t id,
             size_t version,
-            size_t opcode = 0);
+            size_t opcode = 0,
+            bool trim_string_null_terminator = false);
 
         /**
          * <summary>Enables adding new properties to the builder.</summary>
@@ -171,6 +172,7 @@ namespace krabs { namespace testing {
         const size_t opcode_;
         EVENT_HEADER header_;
         std::vector<record_property_thunk> properties_;
+        bool trim_string_null_terminator_;
         friend struct details::property_adder;
     };
 
@@ -198,11 +200,13 @@ namespace krabs { namespace testing {
         const krabs::guid &providerId,
         size_t id,
         size_t version,
-        size_t opcode)
+        size_t opcode,
+        bool trim_string_null_terminator)
     : providerId_(providerId)
     , id_(id)
     , version_(version)
     , opcode_(opcode)
+    , trim_string_null_terminator_(trim_string_null_terminator)
     {
         ZeroMemory(&header_, sizeof(EVENT_HEADER));
         header_.EventDescriptor.Id      = static_cast<USHORT>(id_);
@@ -269,7 +273,13 @@ namespace krabs { namespace testing {
         krabs::schema event_schema(record);
         krabs::parser event_parser(event_schema);
 
+        // When the last property in a record is of string type (ansi or unicode), 
+        // ETW may omit the string NULL terminator. bytes_to_trim below will eventually be
+        // set to the number of bytes that can be trimmed from the generated buffer.
+
+        auto bytes_to_trim = 0;
         for (auto prop : event_parser.properties()) {
+            bytes_to_trim = 0;
 
             auto found_prop = std::find_if(properties_.begin(),
                                            properties_.end(),
@@ -291,6 +301,15 @@ namespace krabs { namespace testing {
                     throw std::invalid_argument(msg.c_str());
                 }
 
+                // if this is a string type, we could trim the null terminator
+                // (assuming that there are no other properties after this one)
+                if (prop.type() == TDH_INTYPE_UNICODESTRING) {
+                    bytes_to_trim = sizeof(L'\0');
+                }
+                else if (prop.type() == TDH_INTYPE_ANSISTRING) {
+                    bytes_to_trim = sizeof('\0');
+                }
+
                 std::copy(found_prop->bytes().begin(),
                           found_prop->bytes().end(),
                           std::back_inserter(results.first));
@@ -305,6 +324,10 @@ namespace krabs { namespace testing {
                 std::fill_n(std::back_inserter(results.first),
                             details::how_many_bytes_to_fill(prop.type()), 0);
             }
+        }
+
+        if (trim_string_null_terminator_) {
+            results.first.resize(results.first.size() - bytes_to_trim);
         }
 
         return results;

--- a/tests/krabstests/test_parser.cpp
+++ b/tests/krabstests/test_parser.cpp
@@ -121,5 +121,24 @@ namespace krabstests
             Assert::AreEqual((BYTE)'T', data.bytes()[0]);
         }
 #endif
+
+        TEST_METHOD(parse_unicode_string_should_work_when_unicode_string_property_is_last_and_not_null_terminated)
+        {
+            std::wstring expectedUrl(L"https://www.foo.com/api/v1/health/check");
+
+            krabs::guid httpsys(L"{dd5ef90a-6398-47a4-ad34-4dcecdef795f}");
+            // httpsys: parse event
+            krabs::testing::record_builder builder(httpsys, krabs::id(2), 0U, 12, true);
+            builder.add_properties()
+                (L"Url", expectedUrl);
+
+            auto record = builder.pack_incomplete();
+            krabs::schema schema(record);
+            krabs::parser parser(schema);
+
+            auto url = parser.parse<std::wstring>(L"Url");
+
+            Assert::AreEqual(expectedUrl, url);
+        }
     };
 }


### PR DESCRIPTION
This set introduces two improvements:

1. The properties cache in the parser could store multiple copies of the same property
This situation could occur because the last property parsed was added to the cache and returned but the buffer pointer and property index were not incremented. This is now fixed: every parsed property can exist in the cache just once and there is no duplicate property parsing.

2. String values (ANSI and UNICODE) that belong to the last property in an event record are not guaranteed to be null-terminated. The code assumes that every string is null-terminated, which causes strlen and wcslen to potentially access invalid memory looking for a null terminator. If the memory access succeeds, the parser will throw an exception as the length of the string property will be too large. These error conditions were exposed when processing events from http.sys. I modeled the fix after the way Microsoft.Diagnostics.Tracing.TraceEventRawReaders deals with strings. All unit tests still pass and the events from http.sys are now processed without errors.