### PR TITLE
system_call_provider fix, and FileIo provider addition

### DIFF
--- a/krabs/krabs/kernel_providers.hpp
+++ b/krabs/krabs/kernel_providers.hpp
@@ -61,6 +61,22 @@ namespace krabs { namespace kernel {
         EVENT_TRACE_FLAG_DISK_IO_INIT,
         krabs::guids::disk_io);
 
+	/**
+	* <summary>A provider that enables file io events</summary>
+	*/
+	CREATE_CONVENIENCE_KERNEL_PROVIDER(
+		file_io_provider,
+		EVENT_TRACE_FLAG_FILE_IO,
+		krabs::guids::file_io);
+
+	/**
+	* <summary>A provider that enables file io events</summary>
+	*/
+	CREATE_CONVENIENCE_KERNEL_PROVIDER(
+		file_init_io_provider,
+		EVENT_TRACE_FLAG_FILE_IO_INIT,
+		krabs::guids::file_io);
+
     /**
      * <summary>A provider that enables thread dispatch events.</summary>
      */

--- a/krabs/krabs/kernel_providers.hpp
+++ b/krabs/krabs/kernel_providers.hpp
@@ -187,7 +187,7 @@ namespace krabs { namespace kernel {
     CREATE_CONVENIENCE_KERNEL_PROVIDER(
         system_call_provider,
         EVENT_TRACE_FLAG_SYSTEMCALL,
-        krabs::guids::system_trace);
+        krabs::guids::perf_info);
 
     /**
      * <summary>A provider that enables thread start and stop events.</summary>


### PR DESCRIPTION
Hi,

It appears that the system_call_provider references the wrong GUID.  According to https://msdn.microsoft.com/en-us/library/windows/desktop/aa964786(v=vs.85).aspx it should be using the PerfInfo GUID and not the SystemTraceControl GUID.

I've also added providers for File IO.