### PR TITLE
Update .nuspec dependency to match the dependency in the build

### DIFF
--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -16,7 +16,7 @@
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>
         <dependencies>
-            <dependency id="boost" version="1.61.0" />
+            <dependency id="boost" version="1.68.0" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
The build uses boost 1.68 but the .nuspec takes a dependency on boost 1.61.