### PR TITLE
Add early return when finding provider by name

### DIFF
--- a/krabs/krabs/provider.hpp
+++ b/krabs/krabs/provider.hpp
@@ -437,6 +437,7 @@ namespace krabs {
                 if (wcscmp(name, providerName.c_str()) == 0){
                     hr = provider->get_Guid(&providerGuid);
                     check_provider_hr(hr, providerName);
+                    break;
                 }
             }
 


### PR DESCRIPTION
Fix #71 by adding a `break` statement when the provider is found