### PR TITLE
Added <vector> include to event_filter.hpp to make it compile on VS2019

### DIFF
--- a/krabs/krabs/filtering/event_filter.hpp
+++ b/krabs/krabs/filtering/event_filter.hpp
@@ -6,6 +6,7 @@
 #include <evntcons.h>
 #include <functional>
 #include <deque>
+#include <vector>
 
 #include "../compiler_check.hpp"
 


### PR DESCRIPTION
event_filter.hpp uses `std::vector` but does not contain `#include <vector>` 

This presumably worked previously because one of the existing includes transitively included vector but that is apparently no longer the case.