### PR TITLE
Catch and swallow destructor exceptions

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Support provider-based event filtering.</releaseNotes>
+        <releaseNotes>Prevent exceptions from leaking out of UserTrace and KernelTrace destructors.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Support provider-based event filtering.</releaseNotes>
+        <releaseNotes>Prevent exceptions from leaking out of UserTrace and KernelTrace destructors.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW/KernelTrace.hpp
+++ b/O365.Security.Native.ETW/KernelTrace.hpp
@@ -113,11 +113,22 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
     inline KernelTrace::~KernelTrace()
     {
-        if (disposed_) {
+        if (disposed_)
+        {
             return;
         }
 
-        Stop();
+        try
+        {
+            Stop();
+        }
+        catch (...)
+        {
+            // Stop may throw if the trace has been removed by another process.
+            // We catch and swallow the exception here to avoid an exception from leaking
+            // out of the destructor, which may cause a crash.
+        }
+
         disposed_ = true;
     }
 

--- a/O365.Security.Native.ETW/UserTrace.hpp
+++ b/O365.Security.Native.ETW/UserTrace.hpp
@@ -122,11 +122,22 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
     inline UserTrace::~UserTrace()
     {
-        if (disposed_) {
+        if (disposed_)
+        {
             return;
         }
 
-        Stop();
+        try
+        {
+            Stop();
+        }
+        catch (...)
+        {
+            // Stop may throw if the trace has been removed by another process.
+            // We catch and swallow the exception here to avoid an exception from leaking
+            // out of the destructor, which may cause a crash.
+        }
+
         disposed_ = true;
     }
 

--- a/O365.Security.Native.ETW/UserTrace.hpp
+++ b/O365.Security.Native.ETW/UserTrace.hpp
@@ -122,17 +122,14 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
     inline UserTrace::~UserTrace()
     {
-        if (disposed_)
-        {
+        if (disposed_) {
             return;
         }
 
-        try
-        {
+        try {
             Stop();
         }
-        catch (...)
-        {
+        catch (...) {
             // Stop may throw if the trace has been removed by another process.
             // We catch and swallow the exception here to avoid an exception from leaking
             // out of the destructor, which may cause a crash.


### PR DESCRIPTION
We have observed a crash in some environments with the following callstack:

![callstack](https://user-images.githubusercontent.com/830389/64039932-b0f0d800-cb10-11e9-88b4-c1b4f1a07b7b.png)
We believe this is occurring during agent shutdown after another process in the environment has attempted to "clean up" the machine state by removing the Krabs user trace session. The `UserTrace` destructor calls `Stop()` which may throw if the trace was not found (see `error_check_common_conditions`). If an exception is thrown in the destructor, the process may exit via `std::terminate` ([ref](https://en.cppreference.com/w/cpp/error/terminate), [ref](https://akrzemi1.wordpress.com/2011/09/21/destructors-that-throw/)).

Our proposed fix is to `try/catch` around the call to `Stop()` in the destructor to prevent exceptions from leaking out of the destructor. We apply the same remedy to `UserTrace` and `KernelTrace` as the condition may occur in both destructors.