### PR TITLE
Add support in C++/CLI for native ETW filtering

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Support provider-based event filtering.</releaseNotes>
+        <releaseNotes>Support provider-based event filtering for managed callers.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Support provider-based event filtering.</releaseNotes>
+        <releaseNotes>Support provider-based event filtering for managed callers.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW/Conversions.hpp
+++ b/O365.Security.Native.ETW/Conversions.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <type_traits>
+
+using namespace System;
+using namespace System::Runtime::InteropServices;
+
+namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
+
+// Converts a CLR List<T> of arithmetic types to a corresponding std::vector<T>
+template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, T> = 0>
+std::vector<T> convert(List<T> ^ list)
+{
+    std::vector<T> vector;
+    vector.reserve(list->Count);
+
+    for each (auto item in list)
+    {
+        vector.push_back(item);
+    }
+
+    return vector;
+}
+
+} } } }

--- a/O365.Security.Native.ETW/Conversions.hpp
+++ b/O365.Security.Native.ETW/Conversions.hpp
@@ -8,14 +8,13 @@
 using namespace System;
 using namespace System::Runtime::InteropServices;
 
-namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
+namespace Microsoft::O365::Security::ETW {
 
 // Converts a CLR List<T> of arithmetic types to a corresponding std::vector<T>
 template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, T> = 0>
-std::vector<T> convert(List<T> ^ list)
+std::vector<T> to_vector(List<T>^ list)
 {
-    std::vector<T> vector;
-    vector.reserve(list->Count);
+    std::vector<T> vector(list->Count);
 
     for each (auto item in list)
     {
@@ -25,4 +24,4 @@ std::vector<T> convert(List<T> ^ list)
     return vector;
 }
 
-} } } }
+}

--- a/O365.Security.Native.ETW/Filtering/EventFilter.hpp
+++ b/O365.Security.Native.ETW/Filtering/EventFilter.hpp
@@ -144,7 +144,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds)
-        : filter_(convert<unsigned short>(eventIds))
+        : filter_(to_vector(eventIds))
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);
@@ -155,7 +155,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds, O365::Security::ETW::Predicate^ pred)
-        : filter_(convert<unsigned short>(eventIds), pred->to_underlying())
+        : filter_(to_vector(eventIds), pred->to_underlying())
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);

--- a/O365.Security.Native.ETW/Filtering/EventFilter.hpp
+++ b/O365.Security.Native.ETW/Filtering/EventFilter.hpp
@@ -106,7 +106,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         GCHandle delegateHandle_;
 
     private:
-        std::vector<unsigned short> CreateFromList(List<unsigned short>^ &listEnumerator);
+        template<typename T>
+        std::vector<T> marshal_as(List<T>^ list);
     };
 
     // Implementation
@@ -146,7 +147,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds)
-        : filter_(CreateFromList(eventIds))
+        : filter_(marshal_as(eventIds))
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);
@@ -157,7 +158,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds, O365::Security::ETW::Predicate^ pred)
-        : filter_(CreateFromList(eventIds), pred->to_underlying())
+        : filter_(marshal_as(eventIds), pred->to_underlying())
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);
@@ -198,16 +199,18 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
     }
 
-    std::vector<unsigned short> EventFilter::CreateFromList(List<unsigned short>^ &list)
+    template<typename T>
+    std::vector<T> EventFilter::marshal_as(List<T>^ list)
     {
-        std::vector<unsigned short> vector;
+        std::vector<T> result;
+        result.reserve(list->Count);
 
-        for each(auto item in list)
+        for each (auto item in list)
         {
-            vector.push_back(item);
+            result.push_back(item);
         }
 
-        return vector;
+        return result;
     }
 
 } } } }

--- a/O365.Security.Native.ETW/Filtering/EventFilter.hpp
+++ b/O365.Security.Native.ETW/Filtering/EventFilter.hpp
@@ -106,8 +106,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         GCHandle delegateHandle_;
 
     private:
-        template<typename T>
-        std::vector<T> marshal_as(List<T>^ list);
+        std::vector<unsigned short> GetVectorFromList(List<unsigned short>^& list);
     };
 
     // Implementation
@@ -147,7 +146,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds)
-        : filter_(marshal_as(eventIds))
+        : filter_(GetVectorFromList(eventIds))
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);
@@ -158,7 +157,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds, O365::Security::ETW::Predicate^ pred)
-        : filter_(marshal_as(eventIds), pred->to_underlying())
+        : filter_(GetVectorFromList(eventIds), pred->to_underlying())
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);
@@ -199,18 +198,17 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
     }
 
-    template<typename T>
-    std::vector<T> EventFilter::marshal_as(List<T>^ list)
+    std::vector<unsigned short> EventFilter::GetVectorFromList(List<unsigned short>^& list)
     {
-        std::vector<T> result;
-        result.reserve(list->Count);
+        std::vector<unsigned short> vector;
+        vector.reserve(list->Count);
 
         for each (auto item in list)
         {
-            result.push_back(item);
+            vector.push_back(item);
         }
 
-        return result;
+        return vector;
     }
 
 } } } }

--- a/O365.Security.Native.ETW/Filtering/EventFilter.hpp
+++ b/O365.Security.Native.ETW/Filtering/EventFilter.hpp
@@ -5,6 +5,7 @@
 
 #include <krabs.hpp>
 
+#include "../Conversions.hpp"
 #include "../EventRecordError.hpp"
 #include "../EventRecord.hpp"
 #include "../EventRecordMetadata.hpp"
@@ -104,9 +105,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         NativePtr<krabs::event_filter> filter_;
         GCHandle delegateHookHandle_;
         GCHandle delegateHandle_;
-
-    private:
-        std::vector<unsigned short> GetVectorFromList(List<unsigned short>^& list);
     };
 
     // Implementation
@@ -146,7 +144,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds)
-        : filter_(GetVectorFromList(eventIds))
+        : filter_(convert<unsigned short>(eventIds))
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);
@@ -157,7 +155,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     }
 
     EventFilter::EventFilter(List<unsigned short>^ eventIds, O365::Security::ETW::Predicate^ pred)
-        : filter_(GetVectorFromList(eventIds), pred->to_underlying())
+        : filter_(convert<unsigned short>(eventIds), pred->to_underlying())
     {
         del_ = gcnew NativeHookDelegate(this, &EventFilter::EventNotification);
         delegateHandle_ = GCHandle::Alloc(del_);
@@ -196,19 +194,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
             OnError(gcnew EventRecordError(msg, metadata));
         }
-    }
-
-    std::vector<unsigned short> EventFilter::GetVectorFromList(List<unsigned short>^& list)
-    {
-        std::vector<unsigned short> vector;
-        vector.reserve(list->Count);
-
-        for each (auto item in list)
-        {
-            vector.push_back(item);
-        }
-
-        return vector;
     }
 
 } } } }

--- a/O365.Security.Native.ETW/Filtering/EventFilter.hpp
+++ b/O365.Security.Native.ETW/Filtering/EventFilter.hpp
@@ -55,13 +55,13 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         EventFilter(unsigned short eventId, O365::Security::ETW::Predicate^ predicate);
 
         /// <summary>
-        /// Constructs an EventFilter with the given event ID and Predicate.
+        /// Constructs an EventFilter with the given event IDs.
         /// </summary>
         /// <param name="eventIds">the event IDs to filter using provider-based filtering</param>
         EventFilter(List<unsigned short>^ eventIds);
 
         /// <summary>
-        /// Constructs an EventFilter with the given event ID and Predicate.
+        /// Constructs an EventFilter with the given event IDs and Predicate.
         /// </summary>
         /// <param name="eventIds">the event IDs to filter using provider-based filtering</param>
         /// <param name="predicate">the predicate to use to filter an event</param>

--- a/O365.Security.Native.ETW/O365.Security.Native.ETW.vcxproj
+++ b/O365.Security.Native.ETW/O365.Security.Native.ETW.vcxproj
@@ -192,6 +192,7 @@
     <ClCompile Include="ETWLib.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Conversions.hpp" />
     <ClInclude Include="Errors.hpp" />
     <ClInclude Include="EventRecordError.hpp" />
     <ClInclude Include="EventRecordMetadata.hpp" />

--- a/O365.Security.Native.ETW/O365.Security.Native.ETW.vcxproj.filters
+++ b/O365.Security.Native.ETW/O365.Security.Native.ETW.vcxproj.filters
@@ -116,6 +116,9 @@
     <ClInclude Include="ITrace.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Conversions.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".nuget\NuGet.Config">

--- a/examples/ManagedExamples/ManagedExamples.csproj
+++ b/examples/ManagedExamples/ManagedExamples.csproj
@@ -67,6 +67,8 @@
     <Compile Include="KernelTrace001.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="UserTrace001.cs" />
+    <Compile Include="UserTrace004.cs" />
+    <Compile Include="UserTrace003.cs" />
     <Compile Include="UserTrace002.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/ManagedExamples/Program.cs
+++ b/examples/ManagedExamples/Program.cs
@@ -11,6 +11,8 @@ namespace ManagedExamples
             KernelTrace001.Start();
             //UserTrace001.Start();
             //UserTrace002.Start();
+            //UserTrace003.Start();
+            //UserTrace004.Start();
             //FakingEvents001.Start();
         }
     }

--- a/examples/ManagedExamples/UserTrace003.cs
+++ b/examples/ManagedExamples/UserTrace003.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// This example shows how to use a user_trace to extract powershell command
+// invocations. It uses event ID filtering built in to ETW for improved performance.
+
+using System;
+using Microsoft.O365.Security.ETW;
+
+namespace ManagedExamples
+{
+    public static class UserTrace003
+    {
+        public static void Start()
+        {
+            // UserTrace instances should be used for any non-kernel traces that are defined
+            // by components or programs in Windows. They can optionally take a name -- if none
+            // is provided, a random GUID is assigned as the name.
+            var trace = new UserTrace();
+
+            // A trace can have any number of providers, which are identified by GUID. These
+            // GUIDs are defined by the components that emit events, and their GUIDs can
+            // usually be found with various ETW tools (like wevutil).
+            var powershellProvider = new Provider(Guid.Parse("{A0C1853B-5C40-4B15-8766-3CF1C58F985A}"));
+
+            // UserTrace providers typically have any and all flags, whose meanings are
+            // unique to the specific providers that are being invoked. To understand these
+            // flags, you'll need to look to the ETW event producer.
+            powershellProvider.Any = Provider.AllBitsSet;
+
+            // In UserTrace002.cs, we use predicate-based filtering to only emit events
+            // for a specific event id.
+            //
+            // Alternatively, we can use ETW-based filtering which is even more performant.
+            var filter = new EventFilter(7937);
+
+            // EventFilters have attached callbacks, just like a regular provider.
+            filter.OnEvent += (record) =>
+            {
+                System.Diagnostics.Debug.Assert(record.Id == 7937);
+                Console.WriteLine("Event 7937 received");
+            };
+
+            // EventFilters are attached to providers. Events that are attached to the filter
+            // will only be called when the filter allows the event through. Any events attached
+            // to the provider directly will be called for all events that are fired by the ETW
+            // producer.
+            powershellProvider.AddFilter(filter);
+            trace.Enable(powershellProvider);
+            trace.Start();
+        }
+    }
+}

--- a/examples/ManagedExamples/UserTrace004.cs
+++ b/examples/ManagedExamples/UserTrace004.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// This example shows how to use a user_trace to extract powershell command
+// invocations. It combines predicate-based and ETW-native filtering.
+
+using System;
+using Microsoft.O365.Security.ETW;
+
+namespace ManagedExamples
+{
+    public static class UserTrace004
+    {
+        public static void Start()
+        {
+            // UserTrace instances should be used for any non-kernel traces that are defined
+            // by components or programs in Windows. They can optionally take a name -- if none
+            // is provided, a random GUID is assigned as the name.
+            var trace = new UserTrace();
+
+            // A trace can have any number of providers, which are identified by GUID. These
+            // GUIDs are defined by the components that emit events, and their GUIDs can
+            // usually be found with various ETW tools (like wevutil).
+            var powershellProvider = new Provider(Guid.Parse("{A0C1853B-5C40-4B15-8766-3CF1C58F985A}"));
+
+            // UserTrace providers typically have any and all flags, whose meanings are
+            // unique to the specific providers that are being invoked. To understand these
+            // flags, you'll need to look to the ETW event producer.
+            powershellProvider.Any = Provider.AllBitsSet;
+
+            // In UserTrace003.cs, we use ETW-based filtering to select a specific event ID.
+            //
+            // We can combine ETW-based filtering with predicate filters to filter on specific
+            // event properties without impacting performance.
+            var filter = new EventFilter(7937, UnicodeString.Contains("ContextInfo", "Write-Host"));
+
+            // EventFilters have attached callbacks, just like a regular provider.
+            filter.OnEvent += (record) =>
+            {
+                System.Diagnostics.Debug.Assert(record.Id == 7937);
+                Console.WriteLine(record.GetUnicodeString("ContextInfo"));
+            };
+
+            // EventFilters are attached to providers. Events that are attached to the filter
+            // will only be called when the filter allows the event through. Any events attached
+            // to the provider directly will be called for all events that are fired by the ETW
+            // producer.
+            powershellProvider.AddFilter(filter);
+            trace.Enable(powershellProvider);
+            trace.Start();
+        }
+    }
+}


### PR DESCRIPTION
#60 added support for native ETW filtering in krabs `event_filter.hpp`. 

This plumbs support through to `EventFilter.cs` so C++/CLI callers can take advantage of it.