### PR TITLE
  .stop() should always call ControlTrace(STOP) - even if .open()/.start() has not been called

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Filtering/Fluent.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Filtering/Fluent.hpp
@@ -91,17 +91,17 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
             return Predicate::make_predicate<krabs::predicates::process_id_is>(processId);
         }
 
-		/// <summary>
-		/// Used to verify that an event was emitted with a specific UInt32 property.
-		/// </summary>
-		/// <param name="propertyName">the name of the property to match on</param>
-		/// <param name="value">the value of the property to match on</param>
-		/// <returns>a predicate that matches events of the specified UInt32 property</returns>
-		static Predicate ^IsUInt32(String ^propertyName, UInt32 value)
-		{
-			return gcnew Predicate(krabs::predicates::property_is<UInt32>(
-				msclr::interop::marshal_as<std::wstring>(propertyName),
-				value));
-		}
+        /// <summary>
+        /// Used to verify that an event was emitted with a specific UInt32 property.
+        /// </summary>
+        /// <param name="propertyName">the name of the property to match on</param>
+        /// <param name="value">the value of the property to match on</param>
+        /// <returns>a predicate that matches events of the specified UInt32 property</returns>
+        static Predicate ^IsUInt32(String ^propertyName, UInt32 value)
+        {
+            return gcnew Predicate(krabs::predicates::property_is<UInt32>(
+                msclr::interop::marshal_as<std::wstring>(propertyName),
+                value));
+        }
     };
 } } } }

--- a/Microsoft.O365.Security.Native.ETW/Kernel/KernelProviders.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Kernel/KernelProviders.hpp
@@ -47,7 +47,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW { name
     /// <summary>A provider that enables file I/O name events.</summary>
     CREATE_CONVENIENCE_KERNEL_PROVIDER(
         DiskFileIoProvider,
-		EVENT_TRACE_FLAG_DISK_FILE_IO | EVENT_TRACE_FLAG_DISK_IO,
+        EVENT_TRACE_FLAG_DISK_FILE_IO | EVENT_TRACE_FLAG_DISK_IO,
         FromGuid(krabs::guids::disk_io));
 
     /// <summary>A provider that enables disk I/O completion events.</summary>

--- a/examples/NativeExamples/user_trace_005.cpp
+++ b/examples/NativeExamples/user_trace_005.cpp
@@ -15,17 +15,17 @@ void user_trace_005::start()
     // SYSTEM is required for the Microsoft-Windows-Security-Auditing provider.
     char user_name[128] = { 0 };
     DWORD user_name_length = 128;
-	if (!GetUserNameA(user_name, &user_name_length) || !strcmp(user_name, "SYSTEM") == 0)
+    if (!GetUserNameA(user_name, &user_name_length) || !strcmp(user_name, "SYSTEM") == 0)
     {
         std::wcout << L"Microsoft-Windows-Security-Auditing can only be traced by SYSTEM" << std::endl;
         return;
     }
 
-	// Further, only one trace session is allowed for this provider.
+    // Further, only one trace session is allowed for this provider.
     // This session is created by the OS and is called 'EventLog-Security'.
     // We can't stop() this session, but we can open() a handle to it.
-	krabs::user_trace trace(L"EventLog-Security");
-	krabs::provider<> provider(L"Microsoft-Windows-Security-Auditing");
+    krabs::user_trace trace(L"EventLog-Security");
+    krabs::provider<> provider(L"Microsoft-Windows-Security-Auditing");
 
     // We also can't modify the flags of the trace session.
     // This will silently fail.

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -267,18 +267,18 @@ namespace krabs { namespace details {
     template <typename T>
     EVENT_TRACE_PROPERTIES trace_manager<T>::query_trace()
     {
-		trace_info info = fill_trace_info();
-		ULONG status = ControlTrace(
-			NULL,
-			trace_.name_.c_str(),
-			&info.properties,
-			EVENT_TRACE_CONTROL_QUERY);
+        trace_info info = fill_trace_info();
+        ULONG status = ControlTrace(
+            NULL,
+            trace_.name_.c_str(),
+            &info.properties,
+            EVENT_TRACE_CONTROL_QUERY);
 
-		if (status != ERROR_WMI_INSTANCE_NOT_FOUND) {
-			error_check_common_conditions(status);
+        if (status != ERROR_WMI_INSTANCE_NOT_FOUND) {
+            error_check_common_conditions(status);
 
             return info.properties;
-		}
+        }
 
         return { };
     }

--- a/krabs/krabs/kernel_providers.hpp
+++ b/krabs/krabs/kernel_providers.hpp
@@ -61,29 +61,29 @@ namespace krabs { namespace kernel {
         EVENT_TRACE_FLAG_DISK_IO,
         krabs::guids::disk_io);
 
-	/**
+    /**
      * <summary>A provider that enables disk I/O start events.</summary>
     */
-	CREATE_CONVENIENCE_KERNEL_PROVIDER(
+    CREATE_CONVENIENCE_KERNEL_PROVIDER(
         disk_init_io_provider,
         EVENT_TRACE_FLAG_DISK_IO_INIT,
         krabs::guids::disk_io);
 
-	/**
-	* <summary>A provider that enables file I/O completion events.</summary>
-	*/
-	CREATE_CONVENIENCE_KERNEL_PROVIDER(
-		file_io_provider,
-		EVENT_TRACE_FLAG_FILE_IO,
-		krabs::guids::file_io);
+    /**
+    * <summary>A provider that enables file I/O completion events.</summary>
+    */
+    CREATE_CONVENIENCE_KERNEL_PROVIDER(
+        file_io_provider,
+        EVENT_TRACE_FLAG_FILE_IO,
+        krabs::guids::file_io);
 
-	/**
-	* <summary>A provider that enables file I/O start events.</summary>
-	*/
-	CREATE_CONVENIENCE_KERNEL_PROVIDER(
-		file_init_io_provider,
-		EVENT_TRACE_FLAG_FILE_IO_INIT,
-		krabs::guids::file_io);
+    /**
+    * <summary>A provider that enables file I/O start events.</summary>
+    */
+    CREATE_CONVENIENCE_KERNEL_PROVIDER(
+        file_init_io_provider,
+        EVENT_TRACE_FLAG_FILE_IO_INIT,
+        krabs::guids::file_io);
 
     /**
      * <summary>A provider that enables thread dispatch events.</summary>

--- a/tests/krabstests/test_user_providers.cpp
+++ b/tests/krabstests/test_user_providers.cpp
@@ -99,7 +99,7 @@ namespace krabstests
             // matching name is running
             krabs::user_trace trace(TEST_TRACE_NAME);
             while (0 == trace.query_stats().buffersCount) {
-				Sleep(500);
+                Sleep(500);
             }
 
             // and we can stop traces by name


### PR DESCRIPTION
In C# I wanted to be able to call .stop() to clean up orphan traces - without having to start processing events.

Originally I planned to add C++/CLI support for .open() which should(?) have worked. But when I dug into it, it seemed neater to just always (blindly) call STOP and swallow any 'not found' status codes. Thoughts?


~~I then also noticed a superfluous call to unregister_trace() and that CloseTrace() was *never* being called.  (See comment on https://github.com/microsoft/krabsetw/pull/82)  So I've proposed a fix for this logic.~~

And finally, I propose renaming unregister_trace() ~~to~~ *and* stop_trace() ~~and vice versa~~.
unregister_trace was calling ControlTrace(STOP) - which is the converse operation to start_trace() *so rename to stop_trace()*
stop_trace was calling CloseTrace() on the session handle - which is the converse operation to ~~register_trace()~~ *open_trace(), so rename to close_trace()*