### PR TITLE
updated exception to reflect decoupling of open() and process()

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Errors.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Errors.hpp
@@ -16,9 +16,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     public ref struct InvalidParameter : public System::Exception {};
 
     /// <summary>
-    /// Thrown when the trace fails to start.
+    /// Thrown when the trace fails to open.
     /// </summary>
-    public ref struct StartTraceFailure : public System::Exception {};
+    public ref struct OpenTraceFailure : public System::Exception {};
 
     /// <summary>
     /// Thrown when the schema for an event could not be found.
@@ -58,9 +58,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         { \
             throw gcnew InvalidParameter; \
         } \
-        catch (const krabs::start_trace_failure &) \
+        catch (const krabs::open_trace_failure &) \
         { \
-            throw gcnew StartTraceFailure; \
+            throw gcnew OpenTraceFailure; \
         } \
         catch (const krabs::no_trace_sessions_remaining &) \
         { \

--- a/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
@@ -147,9 +147,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         {
             throw gcnew InvalidParameter;
         }
-        catch (const krabs::start_trace_failure &)
+        catch (const krabs::open_trace_failure &)
         {
-            throw gcnew StartTraceFailure;
+            throw gcnew OpenTraceFailure;
         }
         catch (const krabs::no_trace_sessions_remaining &)
         {

--- a/krabs/krabs/errors.hpp
+++ b/krabs/krabs/errors.hpp
@@ -23,10 +23,10 @@ namespace krabs {
         {}
     };
 
-    class start_trace_failure : public std::runtime_error {
+    class open_trace_failure : public std::runtime_error {
     public:
-        start_trace_failure()
-            : std::runtime_error("Failure to start trace")
+        open_trace_failure()
+            : std::runtime_error("Failure to open trace")
         {}
     };
 

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -318,7 +318,7 @@ namespace krabs { namespace details {
         auto file = fill_logfile();
         trace_.sessionHandle_ = OpenTrace(&file);
         if (trace_.sessionHandle_ == INVALID_PROCESSTRACE_HANDLE) {
-            throw start_trace_failure();
+            throw open_trace_failure();
         }
         return file;
     }
@@ -327,7 +327,7 @@ namespace krabs { namespace details {
     void trace_manager<T>::process_trace()
     {
         if (trace_.sessionHandle_ == INVALID_PROCESSTRACE_HANDLE) {
-            throw start_trace_failure();
+            throw open_trace_failure();
         }
 
         ::FILETIME now;


### PR DESCRIPTION
It bugged me that I could get a start_trace_failure before I called start().  ¯\_(ツ)_/¯ 

(This is due to the introduction of open() in https://github.com/microsoft/krabsetw/pull/54).
It just seems cleaner to me to have an open_trace_failure instead...  :-)