### PR TITLE
deprecate process()

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
@@ -100,28 +100,13 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         ///     // ...
         ///     trace.Open();
         ///     // ...
-        ///     trace.Process();
-        /// </example>
-        virtual void Open();
-
-        /// <summary>
-        /// Initiates the event processing loop for an open trace session.
-        /// </summary>
-        /// <example>
-        ///     var trace = new KernelTrace();
-        ///     // ...
-        ///     trace.Open();
-        ///     // ...
-        ///     trace.Process();
+        ///     trace.Start();
         /// </example>
         /// <remarks>
-        /// This function is a blocking call. Whichever thread calls Start() is effectively
-        /// donating itself to the ETW subsystem as the processing thread for events.
-        ///
-        /// A side effect of this is that it is expected that Stop() will be called on
-        /// a different thread.
+        /// This is an optional call before Start() if you need the trace
+        /// registered with the ETW subsystem before you start processing events.
         /// </remarks>
-        virtual void Process();
+        virtual void Open();
 
         /// <summary>
         /// Starts listening for events from the enabled providers.
@@ -205,11 +190,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline void KernelTrace::Open()
     {
         ExecuteAndConvertExceptions((void)trace_->open());
-    }
-
-    inline void KernelTrace::Process()
-    {
-        ExecuteAndConvertExceptions(trace_->process());
     }
 
     inline void KernelTrace::Start()

--- a/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
@@ -108,28 +108,13 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         ///     // ...
         ///     trace.Open();
         ///     // ...
-        ///     trace.Process();
-        /// </example>
-        virtual void Open();
-
-        /// <summary>
-        /// Initiates the event processing loop for an open trace session.
-        /// </summary>
-        /// <example>
-        ///     var trace = new UserTrace();
-        ///     // ...
-        ///     trace.Open();
-        ///     // ...
-        ///     trace.Process();
+        ///     trace.Start();
         /// </example>
         /// <remarks>
-        /// This function is a blocking call. Whichever thread calls Start() is effectively
-        /// donating itself to the ETW subsystem as the processing thread for events.
-        ///
-        /// A side effect of this is that it is expected that Stop() will be called on
-        /// a different thread.
+        /// This is an optional call before Start() if you need the trace
+        /// registered with the ETW subsystem before you start processing events.
         /// </remarks>
-        virtual void Process();
+        virtual void Open();
 
         /// <summary>
         /// Starts listening for events from the enabled providers.
@@ -219,11 +204,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline void UserTrace::Open()
     {
         ExecuteAndConvertExceptions((void)trace_->open());
-    }
-
-    inline void UserTrace::Process()
-    {
-        ExecuteAndConvertExceptions(trace_->process());
     }
 
     inline void UserTrace::Start()

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -63,13 +63,6 @@ namespace krabs { namespace details {
         EVENT_TRACE_LOGFILE open();
 
         /**
-        * <summary>
-        * Starts processing the ETW trace. Must be preceeded by a call to open.
-        * </summary>
-        */
-        void process();
-
-        /**
          * <summary>
          * Queries the ETW trace identified by the info in the trace type.
          * </summary>
@@ -158,7 +151,9 @@ namespace krabs { namespace details {
     template <typename T>
     void trace_manager<T>::start()
     {
-        (void)open();
+        if (trace_.sessionHandle_ == INVALID_PROCESSTRACE_HANDLE) {
+            (void)open();
+        }
         process_trace();
     }
 
@@ -168,12 +163,6 @@ namespace krabs { namespace details {
         register_trace();
         enable_providers();
         return open_trace();
-    }
-
-    template <typename T>
-    void trace_manager<T>::process()
-    {
-        process_trace();
     }
 
     template <typename T>

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -167,6 +167,8 @@ namespace krabs {
         /**
         * <summary>
         * Opens a trace session.
+        * This is an optional call before start() if you need the trace
+        * registered with the ETW subsystem before you start processing events.
         * </summary>
         * <example>
         *    krabs::trace trace;
@@ -180,17 +182,10 @@ namespace krabs {
 
         /**
         * <summary>
-        * Initiates the processing loop for an open trace session.
+        * This is an alias for start().
         * </summary>
-        * <example>
-        *    krabs::trace trace;
-        *    krabs::guid id(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
-        *    provider<> powershell(id);
-        *    trace.enable(powershell);
-        *    auto logfile = trace.open();
-        *    trace.process();
-        * </example>
         */
+        [[deprecated("use start() instead")]]
         void process();
 
         /**
@@ -330,8 +325,7 @@ namespace krabs {
     template <typename T>
     void trace<T>::process()
     {
-        details::trace_manager<trace> manager(*this);
-        return manager.process();
+        trace<T>::start();
     }
 
     template <typename T>


### PR DESCRIPTION
On second though, process() is a bit redundant and could be deprecated.

