### PR TITLE
Update Nuget versions to 3.0.0

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>2.0.3</version>
+        <version>3.0.0</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Support provider-based event filtering for managed callers.</releaseNotes>
+        <releaseNotes>Support specifying trace properties when creating a new trace.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>2.0.3</version>
+        <version>3.0.0</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Support provider-based event filtering for managed callers.</releaseNotes>
+        <releaseNotes>Support specifying trace properties when creating a new trace.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -35,12 +35,12 @@
         <file src="krabs\krabs\collection_view.hpp" target="lib\native\include\krabs\collection_view.hpp" />
         <file src="krabs\krabs\compiler_check.hpp" target="lib\native\include\krabs\compiler_check.hpp" />
         <file src="krabs\krabs\errors.hpp" target="lib\native\include\krabs\errors.hpp" />
+        <file src="krabs\krabs\etw.hpp" target="lib\native\include\krabs\etw.hpp" />
         <file src="krabs\krabs\guid.hpp" target="lib\native\include\krabs\guid.hpp" />
         <file src="krabs\krabs\kernel_guids.hpp" target="lib\native\include\krabs\kernel_guids.hpp" />
         <file src="krabs\krabs\kernel_providers.hpp" target="lib\native\include\krabs\kernel_providers.hpp" />
         <file src="krabs\krabs\kt.hpp" target="lib\native\include\krabs\kt.hpp" />
         <file src="krabs\krabs\lock.hpp" target="lib\native\include\krabs\lock.hpp" />
-        <file src="krabs\krabs\nightmare.hpp" target="lib\native\include\krabs\nightmare.hpp" />
         <file src="krabs\krabs\parser.hpp" target="lib\native\include\krabs\parser.hpp" />
         <file src="krabs\krabs\parse_types.hpp" target="lib\native\include\krabs\parse_types.hpp" />
         <file src="krabs\krabs\property.hpp" target="lib\native\include\krabs\property.hpp" />
@@ -54,6 +54,6 @@
         <file src="krabs\krabs\version_helpers.hpp" target="lib\native\include\krabs\version_helpers.hpp" />
         <file src="krabs\krabs.hpp" target="lib\native\include\krabs.hpp" />
         <file src="krabs\krabs.cpp" target="lib\native\src\krabs.cpp" />
-        <file src="krabs\Readme.txt" target="Readme.txt" />
+        <file src="krabs\Readme.md" target="Readme.md" />
     </files>
 </package>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Support provider-based event filtering.</releaseNotes>
+        <releaseNotes>Support specifying trace properties when creating a new trace.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>2.0.3</version>
+        <version>3.0.0</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/tests/ManagedETWTests/EtwTestsCS.csproj
+++ b/tests/ManagedETWTests/EtwTestsCS.csproj
@@ -26,6 +26,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -35,6 +36,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugSigning|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +46,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseSigning|x64'">
     <OutputPath>bin\x64\ReleaseSigning\</OutputPath>
@@ -53,6 +56,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
- Bumped the major version since we've made a change to the public API
- Added `<LangVersion>latest</LangVersion>` where needed to support `ref struct` in C#