### PR TITLE
PreBuildEvent that was looking for 35MSSharedLib1024.snk in wrong folder

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj
+++ b/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj
@@ -96,7 +96,7 @@
       <AssemblyDebug>true</AssemblyDebug>
     </Link>
     <PreBuildEvent>
-      <Command>if not exist $(SolutionDir)..\35MSSharedLib1024.snk sn.exe -k $(SolutionDir)..\35MSSharedLib1024.snk</Command>
+      <Command>if not exist $(ProjectDir)..\35MSSharedLib1024.snk sn.exe -k $(ProjectDir)..\35MSSharedLib1024.snk</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Verify snk file is generated</Message>
@@ -120,7 +120,7 @@
       <AssemblyDebug>true</AssemblyDebug>
     </Link>
     <PreBuildEvent>
-      <Command>if not exist $(SolutionDir)..\35MSSharedLib1024.snk sn.exe -k $(SolutionDir)..\35MSSharedLib1024.snk</Command>
+      <Command>if not exist $(ProjectDir)..\35MSSharedLib1024.snk sn.exe -k $(ProjectDir)..\35MSSharedLib1024.snk</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Verify snk file is generated</Message>
@@ -151,7 +151,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>if not exist $(SolutionDir)..\35MSSharedLib1024.snk sn.exe -k $(SolutionDir)..\35MSSharedLib1024.snk</Command>
+      <Command>if not exist $(ProjectDir)..\35MSSharedLib1024.snk sn.exe -k $(ProjectDir)..\35MSSharedLib1024.snk</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Verify snk file is generated</Message>
@@ -172,7 +172,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>if not exist $(SolutionDir)..\35MSSharedLib1024.snk sn.exe -k $(SolutionDir)..\35MSSharedLib1024.snk</Command>
+      <Command>if not exist $(ProjectDir)..\35MSSharedLib1024.snk sn.exe -k $(ProjectDir)..\35MSSharedLib1024.snk</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Verify snk file is generated</Message>


### PR DESCRIPTION
Linked to my Issue related to building KrabsETW Native as part of my own external project: https://github.com/microsoft/krabsetw/issues/101

`$(SolutionDir)...` puts the file outside the codebase, so I'm assuming this was a mistake? `$(ProjectDir)...` seems to make more sence, as that puts it at the project root, where there is the file already existing in the codebase: https://github.com/microsoft/krabsetw/blob/master/35MSSharedLib1024.snk 