### PR TITLE
Suppress wchar_t to char narrowing when constructing error messages

### DIFF
--- a/krabs/krabs/guid.hpp
+++ b/krabs/krabs/guid.hpp
@@ -59,7 +59,10 @@ namespace krabs {
     {
         HRESULT hr = CLSIDFromString(guid.c_str(), &guid_);
         if (FAILED(hr)) {
+#pragma warning(push)
+#pragma warning(disable: 4244) // narrowing guid wchar_t to char for this error message
             std::string guidStr(guid.begin(), guid.end());
+#pragma warning(pop)
             std::stringstream stream;
             stream << "Error in constructing guid from string (";
             stream << guidStr;

--- a/krabs/krabs/tdh_helpers.hpp
+++ b/krabs/krabs/tdh_helpers.hpp
@@ -101,7 +101,10 @@ namespace krabs {
 
             if (requested == actual) return;
 
+#pragma warning(push)
+#pragma warning(disable: 4244) // narrowing property name wchar_t to char for this error message
             std::string ansiName(name.begin(), name.end());
+#pragma warning(pop)
 
             throw type_mismatch_assert(
                 ansiName.c_str(),

--- a/krabs/krabs/testing/record_builder.hpp
+++ b/krabs/krabs/testing/record_builder.hpp
@@ -233,8 +233,12 @@ namespace krabs { namespace testing {
         if (!results.second.empty()) {
             std::string msg = "Not all the properties of the event were filled:";
 
-            for (auto& s : results.second)
+            for (auto& s : results.second) {
+#pragma warning(push)
+#pragma warning(disable: 4244) // narrowing property name wchar_t to char for this error message
                 msg += " " + std::string(s.begin(), s.end());
+#pragma warning(pop)
+            }
 
             throw std::invalid_argument(msg);
         }


### PR DESCRIPTION
Fix #114 