### PR TITLE
Widen trace_flags_ to ULONG to match ENABLE_TRACE_PARAMETERS.EnableProperty

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Provider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Provider.hpp
@@ -123,7 +123,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// </summary>
         property TraceFlags TraceFlags {
             void set(O365::Security::ETW::TraceFlags value) {
-                provider_->trace_flags((UCHAR)value);
+                provider_->trace_flags((ULONG)value);
             }
         }
 

--- a/krabs/krabs/provider.hpp
+++ b/krabs/krabs/provider.hpp
@@ -517,7 +517,7 @@ namespace krabs {
         tmp.any_            = static_cast<ULONGLONG>(any_);
         tmp.all_            = static_cast<ULONGLONG>(all_);
         tmp.level_          = static_cast<UCHAR>(level_);
-        tmp.trace_flags_    = static_cast<UCHAR>(trace_flags_);
+        tmp.trace_flags_    = static_cast<ULONG>(trace_flags_);
         tmp.callbacks_      = this.callbacks_;
 
         return tmp;

--- a/krabs/krabs/ut.hpp
+++ b/krabs/krabs/ut.hpp
@@ -26,7 +26,7 @@ namespace krabs { namespace details {
             UCHAR level_;
             ULONGLONG any_;
             ULONGLONG all_;
-            UCHAR trace_flags_;
+            ULONG trace_flags_;
         };
 
         struct filter_settings{


### PR DESCRIPTION
trace_flags_ is currently a UCHAR, which is a narrower data type than required for some of the new flags specified in evntcons.h for ENABLE_TRACE_PARAMETERS.EnableProperty (which is type ULONG), starting in Windows SDK version 10.0.19041.0. 

This PR widens trace_flags_ to support using the new flags.