### PR TITLE
Add getter for property Provider.TraceFlags

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Provider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Provider.hpp
@@ -117,11 +117,15 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
 
         /// <summary>
-        /// Represents the "level" value on the provider's options, where
-        /// "level" determines events in what categories are 
-        /// enabled for notification.
+        /// Represents the "EnabledProperty" value on the provider's options.
+        /// Values are documented here:
+        /// https://docs.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-enable_trace_parameters
         /// </summary>
         property TraceFlags TraceFlags {
+            ETW::TraceFlags get() {
+                return static_cast<ETW::TraceFlags>(provider_->trace_flags());
+            }
+
             void set(O365::Security::ETW::TraceFlags value) {
                 provider_->trace_flags((ULONG)value);
             }

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.2</version>
+        <version>4.1.3</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Widen trace_flags_ to support additional flags.</releaseNotes>
+        <releaseNotes>Add getter for property Provider.TraceFlags.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.2</version>
+        <version>4.1.3</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Widen trace_flags_ to support additional flags.</releaseNotes>
+        <releaseNotes>Add getter for property Provider.TraceFlags.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabs/krabs/provider.hpp
+++ b/krabs/krabs/provider.hpp
@@ -225,6 +225,23 @@ namespace krabs {
         void trace_flags(T trace_flags);
 
         /**
+        * <summary>
+        * Gets the configured value for the "EnableProperty" flag on the 
+        * ENABLE_TRACE_PARAMETER struct. See void trace_flags(T trace_flags)
+        * for details on what the values mean.
+        * </summary>
+        * <returns>The value to set when the provider is enabled.</returns>
+        * <example>
+        *    krabs::guid id(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
+        *    provider<> powershell(id);
+        *    powershell.trace_flags(EVENT_ENABLE_PROPERTY_STACK_TRACE);
+        *    auto flags = powershell.get_trace_flags(); 
+        *    assert(flags == EVENT_ENABLE_PROPERTY_STACK_TRACE);
+        * </example>
+        */
+        T trace_flags() const;
+
+        /**
          * <summary>
          * Turns a strongly typed provider<T> to provider<> (useful for
          * creating collections of providers).
@@ -508,6 +525,12 @@ namespace krabs {
     void provider<T>::trace_flags(T trace_flags)
     {
         trace_flags_ = trace_flags;
+    }
+
+    template <typename T>
+    T provider<T>::trace_flags() const
+    {
+        return static_cast<T>(trace_flags_);
     }
 
     template <typename T>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.2</version>
+        <version>4.1.3</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Widen trace_flags_ to support additional flags.</releaseNotes>
+        <releaseNotes>Add getter for property Provider.TraceFlags.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>

--- a/tests/krabstests/test_user_providers.cpp
+++ b/tests/krabstests/test_user_providers.cpp
@@ -112,5 +112,15 @@ namespace krabstests
             // no buffers --> trace has stopped
             Assert::IsTrue(0 == trace.query_stats().buffersCount);
         }
+
+        TEST_METHOD(should_get_same_trace_flags_as_set)
+        {
+            // Take up the full width of the datatype.
+            const ULONG FLAGS = 0xFFFFFFFF;
+
+            krabs::provider<> foo(krabs::guid::random_guid());
+            foo.trace_flags(FLAGS);
+            Assert::IsTrue(foo.trace_flags() == FLAGS);
+        }
     };
 }


### PR DESCRIPTION
Provider.TraceFlags (and the unmanaged provider::trace_flags) were set-only, this change adds a getter in both places.