### PR TITLE
Adds TraceFlags property to RawProvider for parity with Provider.

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
@@ -92,6 +92,21 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
 
         /// <summary>
+        /// Represents the "EnabledProperty" value on the provider's options.
+        /// Values are documented here:
+        /// https://docs.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-enable_trace_parameters
+        /// </summary>
+        property TraceFlags TraceFlags {
+            ETW::TraceFlags get() {
+                return static_cast<ETW::TraceFlags>(provider_->trace_flags());
+            }
+
+            void set(O365::Security::ETW::TraceFlags value) {
+                provider_->trace_flags((ULONG)value);
+            }
+        }
+
+        /// <summary>
         /// An event that is invoked when an ETW event is fired in this
         /// provider.
         /// </summary>

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.3</version>
+        <version>4.1.5</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Add getter for property Provider.TraceFlags.</releaseNotes>
+        <releaseNotes>Add TraceFlags property to RawProvider.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.3</version>
+        <version>4.1.5</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Add getter for property Provider.TraceFlags.</releaseNotes>
+        <releaseNotes>Add TraceFlags property to RawProvider.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.3</version>
+        <version>4.1.5</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Add getter for property Provider.TraceFlags.</releaseNotes>
+        <releaseNotes>Add TraceFlags property to RawProvider.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>


### PR DESCRIPTION
The property works fine, we just need to expose it. :)

Setting nuspec version to 4.1.5 to follow the other PR in the queue, though I'm expecting a merge conflict due to changing the same lines.