### PR TITLE
Read container ID from event extended data

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Errors.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Errors.hpp
@@ -43,6 +43,13 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     };
 
     /// <summary>
+    /// Thrown on internal parsing errors when retrieving container ID's.
+    /// </summary>
+    public ref struct ContainerIdFormatException : public System::Exception {
+        ContainerIdFormatException(System::String^ msg) : System::Exception(msg) {}
+    };
+
+    /// <summary>
     /// Thrown when no trace sessions remaining to register. An existing trace
     /// session must be deleted first.
     /// </summary>

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -172,10 +172,10 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// </returns>
         virtual bool TryGetContainerId([Out] System::Guid% result)
         {
-            auto extended_data_count = static_cast<size_t>(record_->ExtendedDataCount);
-            for (size_t i = 0; i < extended_data_count; i++)
+            auto extended_data_count = record_->ExtendedDataCount;
+            for (USHORT i = 0; i < extended_data_count; i++)
             {
-                EVENT_HEADER_EXTENDED_DATA_ITEM& extended_data = record_->ExtendedData[i];
+                auto& extended_data = record_->ExtendedData[i];
 
                 if (extended_data.ExtType == EVENT_HEADER_EXT_TYPE_CONTAINER_ID)
                 {

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -154,6 +154,65 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
 
 #pragma endregion
+
+#pragma region ExtendedData
+
+        /// <summary>
+        /// If the event's extended data contains an Argon container ID, retrieve it.
+        /// Can be expensive, avoid calling more than once per event.
+        /// </summary>
+        /// <returns>
+        /// A Guid representing the Argon container ID if the data is present. Null it's not present. 
+        /// Throws a ContainerIdFormatException if the container ID is present but parsing fails.
+        /// </returns>
+        virtual System::Nullable<System::Guid> GetContainerId()
+        {
+            // We are expecting format "00000000-0000-0000-0000-0000000000000", 32 hex digits with 4 hyphens
+            const size_t CONTAINER_ID_DATA_LENGTH_IN_BYTES = 36;
+
+            size_t extended_data_count = record_->ExtendedDataCount;
+            for (size_t i = 0; i < extended_data_count; i++)
+            {
+                EVENT_HEADER_EXTENDED_DATA_ITEM& extended_data = record_->ExtendedData[i];
+
+                if (extended_data.ExtType == EVENT_HEADER_EXT_TYPE_CONTAINER_ID)
+                {
+                    // Convert the non-null terminated, no-braces ASCII GUID into a null terminated, curly braces, wide string 
+                    // for parsing.
+                    assert(extended_data.DataSize == CONTAINER_ID_DATA_LENGTH_IN_BYTES);
+                    wchar_t guid_string_buffer[1 + CONTAINER_ID_DATA_LENGTH_IN_BYTES + 2] = L"{00000000-0000-0000-0000-000000000000}";
+                    for (size_t c = 0; c < CONTAINER_ID_DATA_LENGTH_IN_BYTES; c++)
+                    {
+                        guid_string_buffer[c + 1] = (wchar_t)((reinterpret_cast<char*>(extended_data.DataPtr))[c]);
+                    }
+
+                    // Parse GUID in native code to avoid marshalling any strings.
+                    GUID container_guid;
+                    HRESULT guid_conversion_error = CLSIDFromString(guid_string_buffer, &container_guid);
+                    if (guid_conversion_error != S_OK)
+                    {
+                        // As long as we're getting GUIDs in the expected format from the extended data, this shouldn't be 
+                        // happening, but if it does it should be explicit instead of making the event look like it's not coming
+                        // from inside an Argon container.
+                        System::String^ guidData = gcnew System::String(guid_string_buffer);
+                        System::Int32 errorCode = System::Int32(guid_conversion_error);
+                        throw gcnew ContainerIdFormatException(
+                            System::String::Format(
+                                "Failed to convert event's container ID data to GUID. Error code: {0}, Data: {1}",
+                                errorCode,
+                                guidData));
+                    }
+
+                    // Convert to managed System::Guid for returning to managed code.
+                    return System::Nullable<System::Guid>(ConvertGuid(container_guid));
+                }
+            }
+
+            // Not found, return null.
+            return System::Nullable<System::Guid>();
+        }
+
+#pragma endregion
     };
 
 } } } }

--- a/Microsoft.O365.Security.Native.ETW/IEventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/IEventRecordMetadata.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 using namespace System;
+using namespace System::Runtime::InteropServices;
 
 namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
@@ -111,14 +112,15 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 #pragma region ExtendedData
 
         /// <summary>
-        /// If the event's extended data contains an Argon container ID, retrieve it.
+        /// If the event's extended data contains a Windows container ID (i.e. event came from inside
+        /// a container using process isolation), retrieve it.
         /// Can be expensive, avoid calling more than once per event.
         /// </summary>
         /// <returns>
-        /// A Guid representing the Argon container ID if the data is present. Null it's not present. 
-        /// Throws a DataFormatException if the container ID is present but parsing fails.
+        /// True if a Guid was present. False if not. If a Guid was present, it will be written into the result 
+        /// parameter. Throws a ContainerIdFormatException if the container ID is present but parsing fails.
         /// </returns>
-        virtual System::Nullable<System::Guid> GetContainerId();
+        bool TryGetContainerId([Out] System::Guid% result);
 
 #pragma endregion
     };

--- a/Microsoft.O365.Security.Native.ETW/IEventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/IEventRecordMetadata.hpp
@@ -107,6 +107,20 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         array<uint8_t>^ CopyUserData();
 
 #pragma endregion
+
+#pragma region ExtendedData
+
+        /// <summary>
+        /// If the event's extended data contains an Argon container ID, retrieve it.
+        /// Can be expensive, avoid calling more than once per event.
+        /// </summary>
+        /// <returns>
+        /// A Guid representing the Argon container ID if the data is present. Null it's not present. 
+        /// Throws a DataFormatException if the container ID is present but parsing fails.
+        /// </returns>
+        virtual System::Nullable<System::Guid> GetContainerId();
+
+#pragma endregion
     };
 
 } } } }

--- a/Microsoft.O365.Security.Native.ETW/Testing/RecordBuilder.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Testing/RecordBuilder.hpp
@@ -62,6 +62,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW { name
         generic <typename T>
         void AddValue(System::String^ name, T value);
 
+        /// <summary>
+        /// Adds a container ID extended data item
+        /// </summary>
+        void AddContainerId(System::Guid container_id);
+
     internal:
         NativePtr<krabs::testing::record_builder> builder_;
 
@@ -171,6 +176,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW { name
     {
         auto propName = msclr::interop::marshal_as<std::wstring>(name);
         builder_->add_properties()(propName, value);
+    }
+
+    inline void RecordBuilder::AddContainerId(System::Guid container_id)
+    {
+        builder_->add_container_id_extended_data(ConvertGuid(container_id));
     }
 
 } /* namespace Testing */ } /* namespace ETW */ } /* namespace Security */ } /* namespace O365 */ } /* namespace Microsoft */

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Removed dependency on Boost</releaseNotes>
+        <releaseNotes>Added support for reading container ID extended data in managed API.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Removed dependency on Boost</releaseNotes>
+        <releaseNotes>Added support for reading container ID extended data in managed API.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabs/krabs.sln
+++ b/krabs/krabs.sln
@@ -62,6 +62,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testing", "testing", "{9ED1AE76-2EAA-4CCF-8F01-458BDC8BCD53}"
 	ProjectSection(SolutionItems) = preProject
 		krabs\testing\event_filter_proxy.hpp = krabs\testing\event_filter_proxy.hpp
+		krabs\testing\extended_data_builder.hpp = krabs\testing\extended_data_builder.hpp
 		krabs\testing\filler.hpp = krabs\testing\filler.hpp
 		krabs\testing\proxy.hpp = krabs\testing\proxy.hpp
 		krabs\testing\record_builder.hpp = krabs\testing\record_builder.hpp

--- a/krabs/krabs/guid.hpp
+++ b/krabs/krabs/guid.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <sstream>
 #include <iomanip>
+#include <cassert>
 
 #include "compiler_check.hpp"
 
@@ -46,6 +47,54 @@ namespace krabs {
 
     private:
         GUID guid_;
+    };
+
+    /** <summary>
+      * Helper functions for parsing GUID's.
+      * </summary>
+      */
+    class guid_parser {
+        // Implementing in Krabs instead of Lobsters so that we can test it in unmanaged code.
+    private:
+        // Number of characters in the UUID's 8-4-4-4-12 string format.
+        static const size_t UUID_STRING_LENGTH = 36;
+
+        static const unsigned char DELIMITER = '-';
+
+        // Expected character positions of runs of hex digits in 8-4-4-4-12 format, e.g.
+        // 00000000-0000-0000-0000-000000000000
+        // Names correspond to struct members of GUID.
+        static const size_t STR_POSITION_DATA1 = 0;
+        static const size_t STR_POSITION_DATA2 = 8 + 1;
+        static const size_t STR_POSITION_DATA3 = STR_POSITION_DATA2 + 4 + 1;
+        static const size_t STR_POSITION_DATA4_PART1 = STR_POSITION_DATA3 + 4 + 1;
+        static const size_t STR_POSITION_DATA4_PART2 = STR_POSITION_DATA4_PART1 + 4 + 1;
+
+    public:
+        // str_input must have at least 2 valid chars in allocated buffer
+        static bool hex_octet_to_byte(const char* str_input, unsigned char& byte_output);
+        // str_input must have at least 2*sizeof(T) valid chars in allocated buffer
+        template<typename T>
+        static bool hex_string_to_number(const char* str_input, T& int_output);
+        // str_input must have at least 2*byte_count valid chars in allocated buffer,
+        // and byte_output must have at least byte_count bytes in allocated buffer
+        static bool hex_string_to_bytes(const char* str_input, unsigned char* byte_output, size_t byte_count);
+        
+        /** <summary>
+          * Parses GUID of format 8-4-4-4-12, such as 00000000-0000-0000-0000-000000000000.
+          * 
+          * This function is for performance reasons to help deal with container ID extended data, which has 
+          * no null terminator, which would force us to clone the data to append a null terminator in order to
+          * use existing GUID parsing functions. 
+          * 
+          * This does not assume a null-terminated string, and will not respect null terminators. This assumes 
+          * that str has at least (length) valid characters. Since the format is fixed, that means the only 
+          * valid value for length is 36.
+          *
+          * Returns the parsed GUID. Throws a std::runtime_error if it fails.
+          * </summary>
+          */
+        static GUID parse_guid(const char* str, unsigned int length);
     };
 
     // Implementation
@@ -114,6 +163,123 @@ namespace krabs {
             CoTaskMemFree(mem);
         }
     };
+
+    inline bool guid_parser::hex_octet_to_byte(const char* str_input, unsigned char& byte_output)
+    {
+        // Accepts chars '0' through '9' (0x30 to 0x39),
+        // 'A' through 'F' (0x41 to 0x46)
+        // 'a' through 'f' (0x61 to 0x66)
+
+        // Narrow the value later, for safety checking.
+        int value = 0;
+        // most significant digit in the octet
+        char msd = str_input[0];
+        // least significant digit in the octet
+        char lsd = str_input[1];
+
+        if (msd >= '0' && msd <= '9')
+        {
+            value |= ((int)msd & 0x0F) << 4;
+        }
+        else if ((msd >= 'A' && msd <= 'F') || (msd >= 'a' && msd <= 'f'))
+        {
+            value |= (((int)msd & 0x0F) + 9) << 4;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (lsd >= '0' && lsd <= '9')
+        {
+            value |= ((int)lsd & 0x0F);
+        }
+        else if ((lsd >= 'A' && lsd <= 'F') || (lsd >= 'a' && lsd <= 'f'))
+        {
+            value |= (((int)lsd & 0x0F) + 9);
+        }
+        else
+        {
+            return false;
+        }
+
+        assert(value >= 0 && value <= UCHAR_MAX);
+        byte_output = static_cast<unsigned char>(value);
+        return true;
+    }
+
+    template<typename T>
+    bool guid_parser::hex_string_to_number(const char* str_input, T& int_output)
+    {
+        size_t byte_count = sizeof(T);
+        T value = 0;
+        unsigned char byte = 0;
+
+        for (int i = 0; i < byte_count; i++)
+        {
+            if (!guid_parser::hex_octet_to_byte(str_input + i * 2, byte))
+            {
+                return false;
+            }
+
+            value = (value << 8) | static_cast<T>(byte);
+        }
+
+        int_output = value;
+        return true;
+    }
+
+    inline bool guid_parser::hex_string_to_bytes(const char* str_input, unsigned char* byte_output, size_t byte_count)
+    {
+        for (size_t i = 0; i < byte_count; i++)
+        {
+            if (!hex_octet_to_byte(str_input + (i * 2), byte_output[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    inline GUID guid_parser::parse_guid(const char* str, unsigned int length)
+    {
+        if (length != UUID_STRING_LENGTH)
+        {
+            std::stringstream message;
+            message << "Input data has incorrect length. Expected "
+                << UUID_STRING_LENGTH
+                << ", got "
+                << length;
+            throw std::runtime_error(message.str());
+        }
+
+        GUID guid = { 0 };
+
+        // Check that hyphens are in expected places as a formatting issue.
+        if (str[STR_POSITION_DATA2 - 1] != DELIMITER ||
+            str[STR_POSITION_DATA3 - 1] != DELIMITER ||
+            str[STR_POSITION_DATA4_PART1 - 1] != DELIMITER ||
+            str[STR_POSITION_DATA4_PART2 - 1] != DELIMITER)
+        {
+            throw std::runtime_error("Missing a hyphen where one was expected.");
+        }
+
+        // Use from_hex_string for Data1, Data2, and Data3 because of endianness of the data
+        // Use hex_string_to_bytes for Data4's array elements because it's byte by byte instead
+        bool success = guid_parser::hex_string_to_number(str + STR_POSITION_DATA1, guid.Data1)
+            && guid_parser::hex_string_to_number(str + STR_POSITION_DATA2, guid.Data2)
+            && guid_parser::hex_string_to_number(str + STR_POSITION_DATA3, guid.Data3)
+            && guid_parser::hex_string_to_bytes(str + STR_POSITION_DATA4_PART1, reinterpret_cast<unsigned char*>(&guid.Data4[0]), 2)
+            && guid_parser::hex_string_to_bytes(str + STR_POSITION_DATA4_PART2, reinterpret_cast<unsigned char*>(&guid.Data4[2]), 6);
+
+        if (!success)
+        {
+            throw std::runtime_error("GUID string contains non-hex digits where hex digits are expected.");
+        }
+
+        return guid;
+    }
 }
 
 namespace std

--- a/krabs/krabs/testing/extended_data_builder.hpp
+++ b/krabs/krabs/testing/extended_data_builder.hpp
@@ -53,8 +53,9 @@ namespace krabs { namespace testing {
     class extended_data_builder
     {
     public:
-        static const size_t GUID_STRING_LENGTH_WITH_BRACES = 38;
-        static const size_t GUID_STRING_LENGTH_NO_BRACES = 36;
+        static constexpr size_t GUID_STRING_LENGTH_NO_BRACES = 36;
+        static constexpr size_t GUID_STRING_LENGTH_WITH_BRACES = GUID_STRING_LENGTH_NO_BRACES + 2;
+
 
         extended_data_builder()
         : items_()

--- a/krabs/krabs/testing/extended_data_builder.hpp
+++ b/krabs/krabs/testing/extended_data_builder.hpp
@@ -132,14 +132,14 @@ namespace krabs { namespace testing {
         ZeroMemory(data_buffer, data_buffer_size);
 
         // Step 2: Fill the buffer. For each extended data item, write the object into the buffer at the back.
-        EVENT_HEADER_EXTENDED_DATA_ITEM* array_ptr = reinterpret_cast<EVENT_HEADER_EXTENDED_DATA_ITEM*>(data_buffer);
-        BYTE* data_ptr = data_buffer + array_part_size;
+        auto array_ptr = reinterpret_cast<EVENT_HEADER_EXTENDED_DATA_ITEM*>(data_buffer);
+        auto data_ptr = data_buffer + array_part_size;
 
         for (int i = 0; i < items_.size(); i++)
         {
             // 2a: write the struct
-            EVENT_HEADER_EXTENDED_DATA_ITEM& destination = array_ptr[i];
-            const extended_data_thunk& thunk = items_[i];
+            auto& destination = array_ptr[i];
+            const auto& thunk = items_[i];
             
             destination.ExtType = thunk.ext_type_;
             destination.DataSize = static_cast<USHORT>(thunk.bytes_.size());

--- a/krabs/krabs/testing/extended_data_builder.hpp
+++ b/krabs/krabs/testing/extended_data_builder.hpp
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include <evntcons.h>
+#include <WinDef.h>
+#include <objbase.h>
+
+// TODO: Remove this #define once Krabs starts using Windows SDK v. 10.0.19041.0 or later.
+// From evntcons.h starting in Windows SDK v. 10.0.19041.0.
+#ifndef EVENT_HEADER_EXT_TYPE_CONTAINER_ID
+    #define EVENT_HEADER_EXT_TYPE_CONTAINER_ID 16
+#endif
+
+namespace krabs { namespace testing {
+    class extended_data_builder;
+
+    /**
+     * <summary>
+     *   Since extended data items have to be packed later, we have to hold onto the data
+     *   until we're ready to pack it.
+     * </summary>
+     */
+    class extended_data_thunk 
+    {
+    public:
+        extended_data_thunk(USHORT ext_type, BYTE* data, size_t data_length);
+
+    private:
+        // Intentionally not defined.
+        extended_data_thunk();
+
+        USHORT ext_type_;
+        std::vector<BYTE> bytes_;
+
+        friend class extended_data_builder;
+    };
+
+    /**
+     * <summary>
+     *   Generates fake packed EVENT_HEADER_EXTENDED_DATA_ITEM structures to later add into test
+     *   synth_record objects. These are not guaranteed to be indistinguishable from the real
+     *   thing, just good enough to unit test code that reads/interprets extended data.
+     *
+     *   Note for testing: this builder just appends extended data structures, it won't stop you
+     *   from breaking any API invariants, such as only one of a specific extended data item type.
+     * </summary>
+     */
+    class extended_data_builder
+    {
+    public:
+        static const size_t GUID_STRING_LENGTH_WITH_BRACES = 38;
+        static const size_t GUID_STRING_LENGTH_NO_BRACES = 36;
+
+        extended_data_builder()
+        : items_()
+        {}
+
+        // Mocks a container ID type extended data item.
+        void add_container_id(const GUID& container_id);
+
+        // This generates a contiguous buffer holding all of the data for
+        // the extended data items. Non-trivial because the actual structs
+        // have to be a contiguous array, and they each contain pointers,
+        // not offsets, to dynamically sized data buffers.
+        std::pair<std::shared_ptr<BYTE[]>, size_t> pack() const;
+
+        // Returns the value that should correspond with EVENT_RECORD.ExtendedDataCount
+        inline size_t count() const { return items_.size(); }
+
+    private:
+        std::vector<extended_data_thunk> items_;
+    };
+
+    // Implementation
+    // ------------------------------------------------------------------------
+
+    inline extended_data_thunk::extended_data_thunk(USHORT ext_type, BYTE* data, size_t data_length)
+    : ext_type_(ext_type)
+    , bytes_()
+    {
+        bytes_.assign(data, data + data_length);
+    }
+
+    inline void extended_data_builder::add_container_id(const GUID& container_id)
+    {
+        // With null terminator
+        wchar_t wide_guid_buffer[GUID_STRING_LENGTH_WITH_BRACES + 1] = {};
+
+        // No null terminator
+        BYTE guid_data[GUID_STRING_LENGTH_NO_BRACES] = {};
+
+        StringFromGUID2(container_id, wide_guid_buffer, sizeof(wide_guid_buffer));
+
+        for (int i = 0; i < GUID_STRING_LENGTH_NO_BRACES; i++)
+        {
+            // Offset by 1 to ignore the wrapping braces.
+            guid_data[i] = static_cast<BYTE>(wide_guid_buffer[i + 1]);
+        }
+
+        items_.emplace_back(static_cast<USHORT>(EVENT_HEADER_EXT_TYPE_CONTAINER_ID), guid_data, GUID_STRING_LENGTH_NO_BRACES);
+    }
+
+    inline std::pair<std::shared_ptr<BYTE[]>, size_t> extended_data_builder::pack() const
+    {
+        // Return null for buffer if there are no extended data items.
+        if (items_.size() == 0)
+        {
+            return std::make_pair(std::shared_ptr<BYTE[]>(nullptr), 0);
+        }
+
+        BYTE* data_buffer = nullptr;
+        size_t data_buffer_size = 0;
+
+        // Step 1: compute the required buffer size
+        size_t array_part_size = sizeof(EVENT_HEADER_EXTENDED_DATA_ITEM) * items_.size();
+        size_t data_part_size = 0;
+
+        for (const extended_data_thunk& item : items_)
+        {
+            data_part_size += item.bytes_.size();
+        }
+
+        // Allocate the buffer and zero it
+        data_buffer = new BYTE[array_part_size + data_part_size];
+        data_buffer_size = array_part_size + data_part_size;
+        ZeroMemory(data_buffer, data_buffer_size);
+
+        // Step 2: Fill the buffer. For each extended data item, write the object into the buffer at the back.
+        EVENT_HEADER_EXTENDED_DATA_ITEM* array_ptr = reinterpret_cast<EVENT_HEADER_EXTENDED_DATA_ITEM*>(data_buffer);
+        BYTE* data_ptr = data_buffer + array_part_size;
+
+        for (int i = 0; i < items_.size(); i++)
+        {
+            // 2a: write the struct
+            EVENT_HEADER_EXTENDED_DATA_ITEM& destination = array_ptr[i];
+            const extended_data_thunk& thunk = items_[i];
+            
+            destination.ExtType = thunk.ext_type_;
+            destination.DataSize = static_cast<USHORT>(thunk.bytes_.size());
+
+            // 2b: Write the data
+            assert((data_buffer + data_buffer_size) > data_ptr); // prevent wraparound with unsigned int math
+            size_t remaining = (data_buffer + data_buffer_size) - (data_ptr);
+            // Assert that we will not truncate the data due to not allocating enough space in the buffer.
+            assert(remaining >= destination.DataSize);
+            // Make sure we rather not copy all of the data than overrun the buffer.
+            memcpy_s(data_ptr, min(remaining, destination.DataSize), thunk.bytes_.data(), thunk.bytes_.size());
+
+            // 2c: point the DataPtr field at the data
+            destination.DataPtr = reinterpret_cast<ULONGLONG>(data_ptr);
+
+            // 2d: increment the pointer for where to write the next piece of data
+            data_ptr += destination.DataSize;
+        }
+
+        return std::make_pair(std::shared_ptr<BYTE[]>(data_buffer), data_buffer_size);
+    }
+} }

--- a/krabs/krabs/testing/record_builder.hpp
+++ b/krabs/krabs/testing/record_builder.hpp
@@ -137,7 +137,7 @@ namespace krabs { namespace testing {
 
          /**
          * <summary>
-         * Adds extended data representing a GUID for an Argon container ID
+         * Adds extended data representing a GUID for an Windows container ID
          * </summary>
          */
          void add_container_id_extended_data(const GUID& container_id);

--- a/krabs/krabs/testing/record_builder.hpp
+++ b/krabs/krabs/testing/record_builder.hpp
@@ -253,7 +253,7 @@ namespace krabs { namespace testing {
             throw std::invalid_argument(msg);
         }
 
-        // Don't allocate an extended data buffer if it's a size 0 list.
+        // If it's a size 0 list, pack() will return (nullptr, 0) and no buffer is allocated.
         auto extended_data_buffer = extended_data_.pack();
         record.ExtendedData = reinterpret_cast<EVENT_HEADER_EXTENDED_DATA_ITEM*>(extended_data_buffer.first.get());
         record.ExtendedDataCount = static_cast<USHORT>(extended_data_.count());
@@ -267,7 +267,7 @@ namespace krabs { namespace testing {
         EVENT_RECORD record = create_stub_record();
         auto results = pack_impl(record);
 
-        // Don't include allocate and include an extended data PTR if it's a size 0 list.
+        // If it's a size 0 list, pack() will return (nullptr, 0) and no buffer is allocated.
         auto extended_data_buffer = extended_data_.pack();
         record.ExtendedData = reinterpret_cast<EVENT_HEADER_EXTENDED_DATA_ITEM*>(extended_data_buffer.first.get());
         record.ExtendedDataCount = static_cast<USHORT>(extended_data_.count());

--- a/krabs/krabs/testing/synth_record.hpp
+++ b/krabs/krabs/testing/synth_record.hpp
@@ -39,8 +39,23 @@ namespace krabs { namespace testing {
          *   should return this with its `pack` methods.
          * </remarks>
          */
+        synth_record(const EVENT_RECORD& record,
+                     const std::vector<BYTE>& user_data);
+
+        /**
+         * <summary>
+         *   Constructs a synthetic property, given a partially filled
+         *   EVENT_RECORD and a packed sequence of bytes that represent the
+         *   event's user data.
+         * </summary>
+         * <remarks>
+         *   This class should not be directly instantiated -- an record_builder
+         *   should return this with its `pack` methods.
+         * </remarks>
+         */
         synth_record(const EVENT_RECORD &record,
-                     const std::vector<BYTE> &user_data);
+                     const std::vector<BYTE> &user_data,
+                     const std::shared_ptr<BYTE[]> &extended_data);
 
         /**
          * <summary>
@@ -83,6 +98,7 @@ namespace krabs { namespace testing {
 
             swap(left.record_, right.record_);
             swap(left.data_, right.data_);
+            swap(left.extended_data_, right.extended_data_);
         }
 
     private:
@@ -92,16 +108,34 @@ namespace krabs { namespace testing {
 
         EVENT_RECORD record_;
         std::vector<BYTE> data_;
+
+        // extended_data shared PTR is passed around to make sure that the data
+        // buffer is only deleted after all dependent synth_records are deleted.
+        // since the extended data structure uses direct pointers to data
+        // instead of offsets, we can't pass around a vector<BYTE> unless we
+        // also want to redo the pointers every time the buffer is copied.
+        std::shared_ptr<BYTE[]> extended_data_;
     };
 
     // Implementation
     // ------------------------------------------------------------------------
 
+    inline synth_record::synth_record(const EVENT_RECORD& record,
+        const std::vector<BYTE>& user_data)
+    : synth_record(record, user_data, std::shared_ptr<BYTE[]>())
+    {
+        // Empty shared_ptr is fine here because there's no concern
+        // about managing lifetime of an extended data buffer if there
+        // is no extended data buffer.
+    }
+
     inline synth_record::synth_record(
         const EVENT_RECORD &record,
-        const std::vector<BYTE> &user_data)
+        const std::vector<BYTE> &user_data,
+        const std::shared_ptr<BYTE[]> &extended_data)
     : record_(record)
     , data_(user_data)
+    , extended_data_(extended_data)
     {
         if (data_.size() > 0) {
             record_.UserData = &data_[0];
@@ -113,7 +147,7 @@ namespace krabs { namespace testing {
     }
 
     inline synth_record::synth_record(const synth_record& other)
-        : synth_record(other.record_, other.data_)
+        : synth_record(other.record_, other.data_, other.extended_data_)
     { }
 
     inline synth_record::synth_record(synth_record&& other)

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Removed dependency on Boost</releaseNotes>
+        <releaseNotes>Added support for reading container ID extended data in managed API.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>

--- a/tests/ManagedETWTests/Events/PowerShellEvent.cs
+++ b/tests/ManagedETWTests/Events/PowerShellEvent.cs
@@ -30,5 +30,23 @@ namespace EtwTestsCS.Events
                 return rb.Pack();
             }
         }
+
+        public static SynthRecord CreateRecordWithContainerId(
+            string userData,
+            string contextInfo,
+            string payload,
+            Guid containerId)
+        {
+            using (var rb = new RecordBuilder(ProviderId, EventId, Version))
+            {
+                rb.AddUnicodeString(UserData, userData);
+                rb.AddUnicodeString(ContextInfo, contextInfo);
+                rb.AddUnicodeString(Payload, payload);
+
+                rb.AddContainerId(containerId);
+
+                return rb.Pack();
+            }
+        }
     }
 }

--- a/tests/ManagedETWTests/describe_EventRecord.cs
+++ b/tests/ManagedETWTests/describe_EventRecord.cs
@@ -217,8 +217,8 @@ namespace EtwTestsCS
                 var provider = new Provider(PowerShellEvent.ProviderId);
                 provider.OnEvent += e =>
                 {
-                    Guid? containerId = e.GetContainerId();
-                    Assert.IsNotNull(containerId);
+                    Guid containerId;
+                    Assert.IsTrue(e.TryGetContainerId(out containerId));
                     Assert.AreEqual(containerId, guid);
                 };
 

--- a/tests/ManagedETWTests/describe_EventRecord.cs
+++ b/tests/ManagedETWTests/describe_EventRecord.cs
@@ -209,6 +209,23 @@ namespace EtwTestsCS
                 proxy.PushEvent(WinINetEvent.CreateRecord(
                     String.Empty, String.Empty, data));
             }
+
+            [TestMethod]
+            public void it_should_read_container_id()
+            {
+                Guid guid = new Guid();
+                var provider = new Provider(PowerShellEvent.ProviderId);
+                provider.OnEvent += e =>
+                {
+                    Guid? containerId = e.GetContainerId();
+                    Assert.IsNotNull(containerId);
+                    Assert.AreEqual(containerId, guid);
+                };
+
+                trace.Enable(provider);
+                proxy.PushEvent(PowerShellEvent.CreateRecordWithContainerId(
+                    "Test data", String.Empty, String.Empty, guid));
+            }
         }
 
         [TestClass]

--- a/tests/krabstests/krabstests.vcxproj
+++ b/tests/krabstests/krabstests.vcxproj
@@ -201,6 +201,7 @@
     <ClCompile Include="test_collection_view.cpp" />
     <ClCompile Include="test_event_callbacks.cpp" />
     <ClCompile Include="test_filter.cpp" />
+    <ClCompile Include="test_guid_parser.cpp" />
     <ClCompile Include="test_parser.cpp" />
     <ClCompile Include="test_parse_types.cpp" />
     <ClCompile Include="test_trace_properties.cpp" />

--- a/tests/krabstests/krabstests.vcxproj.filters
+++ b/tests/krabstests/krabstests.vcxproj.filters
@@ -46,5 +46,8 @@
     <ClCompile Include="test_trace_properties.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="test_guid_parser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/krabstests/test_guid_parser.cpp
+++ b/tests/krabstests/test_guid_parser.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "CppUnitTest.h"
+#include <krabs.hpp>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace krabstests
+{
+    TEST_CLASS(test_guid_parser)
+    {
+    public:
+        TEST_METHOD(should_parse_single_octet)
+        {
+            // Arbitrary value
+            const char* octet = "9D";
+            unsigned char value = 0;
+            Assert::IsTrue(krabs::guid_parser::hex_octet_to_byte(octet, value));
+            Assert::AreEqual((unsigned int)value, 0x9Du);
+        }
+
+        TEST_METHOD(octet_parsing_should_fail_invalid_hex_chars)
+        {
+            // Arbitrary value
+            const char* octet = "5G";
+            unsigned char value = 0;
+            Assert::IsFalse(krabs::guid_parser::hex_octet_to_byte(octet, value));
+        }
+
+        TEST_METHOD(octet_parsing_should_be_case_insensitive)
+        {
+            // Arbitrary value
+            const char* lowercase = "ab";
+            const char* uppercase = "AB";
+
+            unsigned char lowercase_value = 0;
+            unsigned char uppercase_value = 0;
+
+            Assert::IsTrue(krabs::guid_parser::hex_octet_to_byte(lowercase, lowercase_value));
+            Assert::IsTrue(krabs::guid_parser::hex_octet_to_byte(uppercase, uppercase_value));
+            Assert::AreEqual((unsigned int)lowercase_value, 0xABu);
+            Assert::AreEqual((unsigned int)uppercase_value, 0xABu);
+        }
+
+        TEST_METHOD(should_parse_hex_octet_string)
+        {
+            const char* str = "1234ABCD";
+            unsigned char output[4] = { 0 };
+
+            Assert::IsTrue(krabs::guid_parser::hex_string_to_bytes(str, output, sizeof(output)));
+            Assert::AreEqual((unsigned int)output[0], 0x12u);
+            Assert::AreEqual((unsigned int)output[1], 0x34u);
+            Assert::AreEqual((unsigned int)output[2], 0xABu);
+            Assert::AreEqual((unsigned int)output[3], 0xCDu);
+        }
+
+        TEST_METHOD(should_not_parse_extra_octets)
+        {
+            const char* str = "5678CDEF";
+            unsigned char output[4] = { 0 };
+
+            Assert::IsTrue(krabs::guid_parser::hex_string_to_bytes(str, output, 3));
+            Assert::AreEqual((unsigned int)output[0], 0x56u);
+            Assert::AreEqual((unsigned int)output[1], 0x78u);
+            Assert::AreEqual((unsigned int)output[2], 0xCDu);
+            Assert::AreEqual((unsigned int)output[3], 0x00u);
+        }
+
+        TEST_METHOD(multi_octet_parsing_should_parse_single_octet)
+        {
+            const char* str = "2B";
+            unsigned char output = 0;
+
+            Assert::IsTrue(krabs::guid_parser::hex_string_to_bytes(str, &output, 1));
+            Assert::AreEqual((unsigned int)output, 0x2Bu);
+        }
+
+        TEST_METHOD(multi_octet_parsing_should_fail_on_invalid_hex_char)
+        {
+            const char* str1 = "ABCDEF-123";
+            const char* str2 = "abcdefghij";
+            const char* str3 = "abcdef123\0";
+            unsigned char output[5] = { 0 };
+
+            Assert::IsFalse(krabs::guid_parser::hex_string_to_bytes(str1, output, 5));
+            Assert::IsFalse(krabs::guid_parser::hex_string_to_bytes(str2, output, 5));
+            Assert::IsFalse(krabs::guid_parser::hex_string_to_bytes(str3, output, 5));
+        }
+
+        TEST_METHOD(uint_parsing_should_parse)
+        {
+            const char* str = "12345678";
+            uint32_t value_32 = 0;
+            uint16_t value_16 = 0;
+            
+            Assert::IsTrue(krabs::guid_parser::hex_string_to_number(str, value_32));
+            Assert::IsTrue(krabs::guid_parser::hex_string_to_number(str, value_16));
+
+            Assert::AreEqual(value_32, 0x12345678u);
+            Assert::AreEqual((unsigned int)value_16, 0x1234u);
+        }
+
+        TEST_METHOD(uint_parsing_should_fail_on_invalid_char)
+        {
+            const char* str = "1234567-";
+            unsigned int value = 0;
+            Assert::IsFalse(krabs::guid_parser::hex_string_to_number(str, value));
+        }
+
+        TEST_METHOD(should_parse_guid)
+        {
+            const char* guid_str = "73d28a4b-3fdd-49a5-9ac2-6e3b15a4196a";
+            GUID guid = krabs::guid_parser::parse_guid(guid_str, 36);
+            Assert::IsTrue(guid == krabs::guid(L"{73d28a4b-3fdd-49a5-9ac2-6e3b15a4196a}"));
+        }
+
+        TEST_METHOD(should_parse_case_insensitively)
+        {
+            const char* guid_str = "F81DC00B-B6E6-4E94-B676-77EC5E93CA12";
+            GUID guid = krabs::guid_parser::parse_guid(guid_str, 36);
+            Assert::IsTrue(guid == krabs::guid(L"{F81DC00B-B6E6-4E94-B676-77EC5E93CA12}"));
+        }
+
+        TEST_METHOD(should_parse_without_null_terminator)
+        {
+            const char* guid_str = "e3801e83-3ea3-4437-95ea-0f854b7d783f";
+            const char buffer[36] = { 0 };
+            memcpy((void*)buffer, guid_str, 36);
+
+            GUID guid = krabs::guid_parser::parse_guid(buffer, 36);
+            Assert::IsTrue(guid == krabs::guid(L"{e3801e83-3ea3-4437-95ea-0f854b7d783f}"));
+        }
+
+        TEST_METHOD(should_fail_with_incorrect_length)
+        {
+            const char* guid_str = "a1219928-a27f-4026-a3ce-b7d3a6dcb633";
+            Assert::ExpectException<std::runtime_error>([guid_str]() 
+                {
+                    GUID guid = krabs::guid_parser::parse_guid(guid_str, 37);
+                });
+        }
+
+        TEST_METHOD(should_fail_with_incorrect_delimiter)
+        {
+            const char* guid_str = "5deadd42 01d5-45f5-b3e2-3fdb5bb63f10";
+            Assert::ExpectException<std::runtime_error>([guid_str]()
+                {
+                    GUID guid = krabs::guid_parser::parse_guid(guid_str, 36);
+                });
+        }
+
+        TEST_METHOD(should_fail_with_incorrect_segment)
+        {
+            const char* guid_str = "1c92843-b85e3-4257-9b0c-f03350bb2253";
+            Assert::ExpectException<std::runtime_error>([guid_str]()
+                {
+                    GUID guid = krabs::guid_parser::parse_guid(guid_str, 36);
+                });
+        }
+    };
+}

--- a/tests/krabstests/test_record_builder.cpp
+++ b/tests/krabstests/test_record_builder.cpp
@@ -211,21 +211,16 @@ namespace krabstests
             Assert::AreEqual((unsigned int)record.ExtendedDataCount, 1u);
             Assert::IsNotNull(record.ExtendedData);
             
-            EVENT_HEADER_EXTENDED_DATA_ITEM& extended_data = record.ExtendedData[0];
+            auto& extended_data = record.ExtendedData[0];
             Assert::AreEqual((unsigned int)extended_data.ExtType, (unsigned int)EVENT_HEADER_EXT_TYPE_CONTAINER_ID);
             Assert::AreEqual((size_t)extended_data.DataSize, krabs::testing::extended_data_builder::GUID_STRING_LENGTH_NO_BRACES);
             
-            // Extract the GUID back out of the extended data, adding wrapping braces and null terminator.
-            std::wstring guid_buffer(L"{########-####-####-####-############}");
-            Assert::AreEqual(guid_buffer.length(), krabs::testing::extended_data_builder::GUID_STRING_LENGTH_WITH_BRACES);
-            for (int i = 0; i < krabs::testing::extended_data_builder::GUID_STRING_LENGTH_NO_BRACES; i++)
-            {
-                // brace offset
-                guid_buffer[i + 1] = static_cast<wchar_t>(reinterpret_cast<char*>(extended_data.DataPtr)[i]);
-            }
+            auto parsed_guid = krabs::guid_parser::parse_guid(
+                reinterpret_cast<const char*>(extended_data.DataPtr), 
+                extended_data.DataSize);
 
             // Check that the right GUID came out.
-            Assert::IsTrue(CONTAINER_GUID == krabs::guid(guid_buffer));
+            Assert::IsTrue(CONTAINER_GUID == krabs::guid(parsed_guid));
         }
 
         private:

--- a/tests/krabstests/test_record_builder.cpp
+++ b/tests/krabstests/test_record_builder.cpp
@@ -139,6 +139,98 @@ namespace krabstests
             Assert::AreEqual(parser.parse<uint32_t>(L"LogonType"), (uint32_t)5);
         }
 
+        TEST_METHOD(pack_should_include_extended_data)
+        {
+            krabs::guid powershell(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
+            krabs::testing::record_builder builder(powershell, krabs::id(7942), krabs::version(1));
+            // Random GUID
+            builder.add_container_id_extended_data(krabs::guid(L"{86E2A814-8893-431D-A1DC-F44931D6B99A}"));
+            
+            // Have to hold onto the record instance so that the data buffers don't get deleted.
+            auto synth_record = builder.pack_incomplete();
+            const EVENT_RECORD& record = synth_record;
+
+            // USHORT has template specialization issues, so use uint.
+            Assert::AreEqual((unsigned int)record.ExtendedDataCount, 1u);
+            Assert::IsNotNull(record.ExtendedData);
+        }
+
+        TEST_METHOD(pack_should_correctly_handle_no_extended_data)
+        {
+            krabs::guid powershell(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
+            krabs::testing::record_builder builder(powershell, krabs::id(7942), krabs::version(1));
+            
+            // Have to hold onto the record instance so that the data buffers don't get deleted.
+            auto synth_record = builder.pack_incomplete();
+            const EVENT_RECORD& record = synth_record;
+            
+            // USHORT has template specialization issues, so use uint.
+            Assert::AreEqual((unsigned int)record.ExtendedDataCount, 0u);
+            Assert::IsNull(record.ExtendedData);
+        }
+
+        TEST_METHOD(pack_should_correctly_handle_multiple_extended_data)
+        {
+            // This assumes that the builder isn't enforcing semantic constraints like "you can't 
+            // have more than one container ID extended data item in the same event". Which is
+            // probably true for events you'd get from the real API, but we're going to exploit the
+            // loophole to test the "multiple extended data" case.
+            krabs::guid powershell(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
+            krabs::testing::record_builder builder(powershell, krabs::id(7942), krabs::version(1));
+            // Random GUID
+            builder.add_container_id_extended_data(krabs::guid(L"{86E2A814-8893-431D-A1DC-F44931D6B99A}"));
+            builder.add_container_id_extended_data(krabs::guid(L"{86E2A814-8893-431D-A1DC-F44931D6B99A}"));
+
+            // Have to hold onto the record instance so that the data buffers don't get deleted.
+            auto synth_record = builder.pack_incomplete();
+            const EVENT_RECORD& record = synth_record;
+
+            // USHORT has template specialization issues, so use uint.
+            Assert::AreEqual((unsigned int)record.ExtendedDataCount, 2u);
+            Assert::IsNotNull(record.ExtendedData);
+
+            // Sanity check
+            Assert::AreEqual((unsigned int)record.ExtendedData[0].ExtType, (unsigned int)EVENT_HEADER_EXT_TYPE_CONTAINER_ID);
+            Assert::AreEqual((unsigned int)record.ExtendedData[1].ExtType, (unsigned int)EVENT_HEADER_EXT_TYPE_CONTAINER_ID);
+        }
+
+        TEST_METHOD(container_id_should_be_read_correctly_after_packing)
+        {
+            // Randomly generated GUID
+            const krabs::guid CONTAINER_GUID(L"{86E2A814-8893-431D-A1DC-F44931D6B99A}");
+
+            krabs::guid powershell(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
+            krabs::testing::record_builder builder(powershell, krabs::id(7942), krabs::version(1));
+            builder.add_container_id_extended_data(CONTAINER_GUID);
+            
+            // Have to hold onto the record instance so that the data buffers don't get deleted.
+            auto synth_record = builder.pack_incomplete();
+            const EVENT_RECORD& record = synth_record;
+
+            // USHORT has template specialization issues, so use uint.
+            Assert::AreEqual((unsigned int)record.ExtendedDataCount, 1u);
+            Assert::IsNotNull(record.ExtendedData);
+            
+            EVENT_HEADER_EXTENDED_DATA_ITEM& extended_data = record.ExtendedData[0];
+            Assert::AreEqual((unsigned int)extended_data.ExtType, (unsigned int)EVENT_HEADER_EXT_TYPE_CONTAINER_ID);
+            Assert::AreEqual((size_t)extended_data.DataSize, krabs::testing::extended_data_builder::GUID_STRING_LENGTH_NO_BRACES);
+            
+            // Extract the GUID back out of the extended data, adding wrapping braces and null terminator.
+            char guid_buffer[krabs::testing::extended_data_builder::GUID_STRING_LENGTH_WITH_BRACES + 1] = "{00000000-0000-0000-0000-000000000000}";
+            errno_t copy_error = memcpy_s(
+                (BYTE*)guid_buffer + 1,
+                krabs::testing::extended_data_builder::GUID_STRING_LENGTH_NO_BRACES,
+                reinterpret_cast<void*>(extended_data.DataPtr),
+                extended_data.DataSize);
+
+            // memcpy_s error would indicate the generated data is incorrectly packed/formatted.
+            Assert::AreEqual((int)copy_error, 0, L"memcpy_s error, most likely means extended data payload was incorrectly packed.");
+
+            // Check that the right GUID came out.
+            std::string container_guid(guid_buffer);
+            Assert::IsTrue(CONTAINER_GUID == krabs::guid(std::wstring(container_guid.begin(), container_guid.end())));
+        }
+
         private:
             krabs::schema_locator schema_locator_;
     };

--- a/tests/krabstests/test_record_builder.cpp
+++ b/tests/krabstests/test_record_builder.cpp
@@ -216,19 +216,16 @@ namespace krabstests
             Assert::AreEqual((size_t)extended_data.DataSize, krabs::testing::extended_data_builder::GUID_STRING_LENGTH_NO_BRACES);
             
             // Extract the GUID back out of the extended data, adding wrapping braces and null terminator.
-            char guid_buffer[krabs::testing::extended_data_builder::GUID_STRING_LENGTH_WITH_BRACES + 1] = "{00000000-0000-0000-0000-000000000000}";
-            errno_t copy_error = memcpy_s(
-                (BYTE*)guid_buffer + 1,
-                krabs::testing::extended_data_builder::GUID_STRING_LENGTH_NO_BRACES,
-                reinterpret_cast<void*>(extended_data.DataPtr),
-                extended_data.DataSize);
-
-            // memcpy_s error would indicate the generated data is incorrectly packed/formatted.
-            Assert::AreEqual((int)copy_error, 0, L"memcpy_s error, most likely means extended data payload was incorrectly packed.");
+            std::wstring guid_buffer(L"{########-####-####-####-############}");
+            Assert::AreEqual(guid_buffer.length(), krabs::testing::extended_data_builder::GUID_STRING_LENGTH_WITH_BRACES);
+            for (int i = 0; i < krabs::testing::extended_data_builder::GUID_STRING_LENGTH_NO_BRACES; i++)
+            {
+                // brace offset
+                guid_buffer[i + 1] = static_cast<wchar_t>(reinterpret_cast<char*>(extended_data.DataPtr)[i]);
+            }
 
             // Check that the right GUID came out.
-            std::string container_guid(guid_buffer);
-            Assert::IsTrue(CONTAINER_GUID == krabs::guid(std::wstring(container_guid.begin(), container_guid.end())));
+            Assert::IsTrue(CONTAINER_GUID == krabs::guid(guid_buffer));
         }
 
         private:


### PR DESCRIPTION
This change should allow reading Windows container ID's from events coming from both Provider and RawProvider (from the managed API).

There's an extra #ifdef in extended_data_builder.hpp for compatibility with Windows SDK version 10.0.18362.0.

I will add nuspec version changes once it's clear what the version number should be.