### PR TITLE
Remove Boost Dependency

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj
+++ b/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj
@@ -54,7 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-    <Import Project="..\krabs\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\krabs\packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -225,13 +224,6 @@
     <None Include=".nuget\NuGet.Config" />
     <None Include=".nuget\NuGet.exe" />
     <None Include=".nuget\NuGet.targets" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\krabs\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\krabs\packages\boost.1.68.0.0\build\boost.targets'))" />
-  </Target>
 </Project>

--- a/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj.filters
+++ b/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj.filters
@@ -130,6 +130,5 @@
     <None Include=".nuget\NuGet.targets">
       <Filter>.nuget</Filter>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Microsoft.O365.Security.Native.ETW/packages.config
+++ b/Microsoft.O365.Security.Native.ETW/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
-</packages>

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.6</version>
+        <version>4.1.7</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Added 'any_of', 'all_of', and 'none_of' predicates</releaseNotes>
+        <releaseNotes>Removed dependency on Boost</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.6</version>
+        <version>4.1.7</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Added 'any_of', 'all_of', and 'none_of' predicates</releaseNotes>
+        <releaseNotes>Removed dependency on Boost</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/examples/NativeExamples/NativeExamples.vcxproj
+++ b/examples/NativeExamples/NativeExamples.vcxproj
@@ -167,17 +167,6 @@
   <ItemGroup>
     <ClInclude Include="examples.h" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\krabs\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\..\krabs\packages\boost.1.68.0.0\build\boost.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\krabs\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\krabs\packages\boost.1.68.0.0\build\boost.targets'))" />
-  </Target>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/examples/NativeExamples/NativeExamples.vcxproj.filters
+++ b/examples/NativeExamples/NativeExamples.vcxproj.filters
@@ -49,7 +49,4 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
 </Project>

--- a/examples/NativeExamples/packages.config
+++ b/examples/NativeExamples/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
-</packages>

--- a/krabs/krabs/filtering/comparers.hpp
+++ b/krabs/krabs/filtering/comparers.hpp
@@ -8,9 +8,9 @@
 #pragma warning(disable: 4800) // bool warning in boost when _MANAGED flag is set
 #endif
 
+#include <algorithm>
+
 #include "../compiler_check.hpp"
-#include <boost/algorithm/string.hpp>
-#include <boost/range/iterator_range_core.hpp>
 
 #if(_MANAGED)
 #pragma warning(pop)
@@ -32,10 +32,7 @@ namespace krabs { namespace predicates {
             template <typename Iter1, typename Iter2>
             bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
             {
-                auto r1 = boost::make_iterator_range(begin1, end1);
-                auto r2 = boost::make_iterator_range(begin2, end2);
-
-                return boost::equals(r1, r2, Comparer());
+                return std::equal(begin1, end1, begin2, end2, Comparer());
             }
         };
 
@@ -48,10 +45,7 @@ namespace krabs { namespace predicates {
             template <typename Iter1, typename Iter2>
             bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
             {
-                auto r1 = boost::make_iterator_range(begin1, end1);
-                auto r2 = boost::make_iterator_range(begin2, end2);
-
-                return boost::contains(r1, r2, Comparer());
+                return std::search(begin1, end1, begin2, end2, Comparer()) != end1;
             }
         };
 
@@ -64,10 +58,20 @@ namespace krabs { namespace predicates {
             template <typename Iter1, typename Iter2>
             bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
             {
-                auto r1 = boost::make_iterator_range(begin1, end1);
-                auto r2 = boost::make_iterator_range(begin2, end2);
+                const auto dist1 = std::distance(begin1, end1);
+                const auto dist2 = std::distance(begin2, end2);
 
-                return boost::starts_with(r1, r2, Comparer());
+                // always starts with empty range
+                if (dist2 == 0)
+                    return true;
+
+                if (dist2 > dist1)
+                    return false;
+
+                auto prefix_end = begin1;
+                std::advance(prefix_end, dist2);
+
+                return std::equal(begin1, prefix_end, begin2, end2, Comparer());
             }
         };
 
@@ -80,10 +84,20 @@ namespace krabs { namespace predicates {
             template <typename Iter1, typename Iter2>
             bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
             {
-                auto r1 = boost::make_iterator_range(begin1, end1);
-                auto r2 = boost::make_iterator_range(begin2, end2);
+                const auto dist1 = std::distance(begin1, end1);
+                const auto dist2 = std::distance(begin2, end2);
 
-                return boost::ends_with(r1, r2, Comparer());
+                // always ends with empty range
+                if (dist2 == 0)
+                    return true;
+
+                if (dist2 > dist1)
+                    return false;
+
+                auto suffix_begin = begin1;
+                std::advance(suffix_begin, dist1 - dist2);
+
+                return std::equal(suffix_begin, end1, begin2, end2, Comparer());
             }
         };
 

--- a/krabs/krabs/filtering/comparers.hpp
+++ b/krabs/krabs/filtering/comparers.hpp
@@ -45,7 +45,9 @@ namespace krabs { namespace predicates {
             template <typename Iter1, typename Iter2>
             bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
             {
-                return std::search(begin1, end1, begin2, end2, Comparer()) != end1;
+                // semantics of boost::contains() require that empty range is always contained
+                return std::distance(begin2, end2) == 0 ||
+                    std::search(begin1, end1, begin2, end2, Comparer()) != end1;
             }
         };
 

--- a/krabs/krabs/filtering/comparers.hpp
+++ b/krabs/krabs/filtering/comparers.hpp
@@ -21,9 +21,9 @@ namespace krabs { namespace predicates {
         struct equals
         {
             template <typename Iter1, typename Iter2>
-            bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
+            bool operator()(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2) const
             {
-                return std::equal(begin1, end1, begin2, end2, Comparer());
+                return std::equal(first1, last1, first2, last2, Comparer());
             }
         };
 
@@ -34,11 +34,11 @@ namespace krabs { namespace predicates {
         struct contains
         {
             template <typename Iter1, typename Iter2>
-            bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
+            bool operator()(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2) const
             {
                 // empty test range always contained, even when input range empty
-                return std::distance(begin2, end2) == 0 
-                    || std::search(begin1, end1, begin2, end2, Comparer()) != end1;
+                return first2 == last2
+                    || std::search(first1, last1, first2, last2, Comparer()) != last1;
             }
         };
 
@@ -49,10 +49,10 @@ namespace krabs { namespace predicates {
         struct starts_with
         {
             template <typename Iter1, typename Iter2>
-            bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
+            bool operator()(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2) const
             {
-                const auto first_nonequal = std::mismatch(begin1, end1, begin2, end2, Comparer());
-                return first_nonequal.second == end2;
+                const auto first_nonequal = std::mismatch(first1, last1, first2, last2, Comparer());
+                return first_nonequal.second == last2;
             }
         };
 
@@ -63,16 +63,16 @@ namespace krabs { namespace predicates {
         struct ends_with
         {
             template <typename Iter1, typename Iter2>
-            bool operator()(Iter1 begin1, Iter1 end1, Iter2 begin2, Iter2 end2) const
+            bool operator()(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2) const
             {
-                const auto dist1 = std::distance(begin1, end1);
-                const auto dist2 = std::distance(begin2, end2);
+                const auto dist1 = std::distance(first1, last1);
+                const auto dist2 = std::distance(first2, last2);
 
                 if (dist2 > dist1)
                     return false;
 
-                const auto suffix_begin = std::next(begin1, dist1 - dist2);
-                return std::equal(suffix_begin, end1, begin2, end2, Comparer());
+                const auto suffix_begin = std::next(first1, dist1 - dist2);
+                return std::equal(suffix_begin, last1, first2, last2, Comparer());
             }
         };
 

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.6</version>
+        <version>4.1.7</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,13 +11,10 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Added 'any_of', 'all_of', and 'none_of' predicates</releaseNotes>
+        <releaseNotes>Removed dependency on Boost</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>
-        <dependencies>
-            <dependency id="boost" version="1.68.0" />
-        </dependencies>
     </metadata>
     <files>
         <file src="build\native\krabsetw.targets" target="build\native\krabsetw.targets" />

--- a/tests/krabstests/krabstests.vcxproj
+++ b/tests/krabstests/krabstests.vcxproj
@@ -211,17 +211,6 @@
     <ClCompile Include="test_synth_record.cpp" />
     <ClCompile Include="test_kernel_providers.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\krabs\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\..\krabs\packages\boost.1.68.0.0\build\boost.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\krabs\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\krabs\packages\boost.1.68.0.0\build\boost.targets'))" />
-  </Target>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/tests/krabstests/krabstests.vcxproj.filters
+++ b/tests/krabstests/krabstests.vcxproj.filters
@@ -47,7 +47,4 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
 </Project>

--- a/tests/krabstests/packages.config
+++ b/tests/krabstests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
-</packages>


### PR DESCRIPTION
Re-implement four functors in `comparers.hpp` with standard library algorithms in place of Boost algorithms.