### PR TITLE
Fix compiler errors when winternl.h is included before krabs.hpp.

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/krabs/krabs/perfinfo_groupmask.hpp
+++ b/krabs/krabs/perfinfo_groupmask.hpp
@@ -187,7 +187,6 @@ typedef struct _EVENT_TRACE_GROUPMASK_INFORMATION {
 #ifndef _WINTERNL_
 
 typedef enum _SYSTEM_INFORMATION_CLASS {
-    SystemPerformanceTraceInformation = 0x1f
 } SYSTEM_INFORMATION_CLASS;
 
 typedef LONG NTSTATUS;
@@ -199,14 +198,12 @@ extern "C" NTSTATUS NTAPI NtQuerySystemInformation(
     _Out_opt_ PULONG ReturnLength
 );
 
+#endif // _WINTERNL_
+
 extern "C" NTSTATUS NTAPI NtSetSystemInformation(
     _In_ SYSTEM_INFORMATION_CLASS SystemInformationClass,
     _In_reads_bytes_opt_(SystemInformationLength) PVOID SystemInformation,
     _In_ ULONG SystemInformationLength
 );
 
-#else // _WINTERNL_
-
 constexpr auto SystemPerformanceTraceInformation{ static_cast<SYSTEM_INFORMATION_CLASS>(0x1f) };
-
-#endif // _WINTERNL_

--- a/krabs/krabs/perfinfo_groupmask.hpp
+++ b/krabs/krabs/perfinfo_groupmask.hpp
@@ -184,6 +184,8 @@ typedef struct _EVENT_TRACE_GROUPMASK_INFORMATION {
     PERFINFO_GROUPMASK EventTraceGroupMasks;
 } EVENT_TRACE_GROUPMASK_INFORMATION, * PEVENT_TRACE_GROUPMASK_INFORMATION;
 
+#ifndef _WINTERNL_
+
 typedef enum _SYSTEM_INFORMATION_CLASS {
     SystemPerformanceTraceInformation = 0x1f
 } SYSTEM_INFORMATION_CLASS;
@@ -202,3 +204,9 @@ extern "C" NTSTATUS NTAPI NtSetSystemInformation(
     _In_reads_bytes_opt_(SystemInformationLength) PVOID SystemInformation,
     _In_ ULONG SystemInformationLength
 );
+
+#else // _WINTERNL_
+
+constexpr auto SystemPerformanceTraceInformation{ static_cast<SYSTEM_INFORMATION_CLASS>(0x1f) };
+
+#endif // _WINTERNL_

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>


### PR DESCRIPTION
A recent change to krabsetw partially defines an enum that is already defined in winternl.h, and it also declares an NT system call that is already declared in winternl.h. Both of these things cause compiler errors in any project which includes krabs.hpp and winternl.h. This PR adds some preprocessor conditionality to avoid defining and declaring if winternl.h has already been included.