### PR TITLE
added krabs::sid to parse TDH_INTYPE_SID and TDH_INTYPE_WBEMSID types

### DIFF
--- a/krabs/krabs/parse_types.hpp
+++ b/krabs/krabs/parse_types.hpp
@@ -10,6 +10,7 @@
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <sddl.h>
 
 #include <vector>
 #include <type_traits>
@@ -220,6 +221,38 @@ namespace krabs {
             return pPropertyIndex_ != nullptr;
         }
     };
+
+    /**
+    * <summary>
+    * Used to handle parsing of SIDs from either a
+    * SID or WBEMSID property
+    * </summary>
+    */
+    struct sid {
+        // SIDs are variable-length
+        // So the 'best' way to store them is to convert to a string
+        // The other-end can either print the string or call ConvertStringSidToSidA
+        // to get the SID back
+        std::string sid_string;
+
+        static sid from_bytes(const BYTE* bytes, size_t size_in_bytes)
+        {
+            sid ws;
+            LPSTR temp_sid_string;
+            UNREFERENCED_PARAMETER(size_in_bytes);
+
+            if (!ConvertSidToStringSidA((PSID)bytes, &temp_sid_string)) {
+                throw std::runtime_error(
+                    "Failed to get a SID from a property");
+            }
+            ws.sid_string = temp_sid_string;
+            LocalFree(temp_sid_string);
+            return ws;
+        }
+
+    private:
+    };
+
 
     /**
      * <summary>

--- a/krabs/krabs/tdh_helpers.hpp
+++ b/krabs/krabs/tdh_helpers.hpp
@@ -182,6 +182,18 @@ namespace krabs {
             }
         }
 
+        template <>
+        inline void assert_valid_assignment<sid>(
+            const std::wstring&, const property_info& info)
+        {
+            auto InType = info.pEventPropertyInfo_->nonStructType.InType;
+
+            if (InType != TDH_INTYPE_WBEMSID && InType != TDH_INTYPE_SID) {
+                throw std::runtime_error(
+                    "Requested a SID but was neither a SID nor WBEMSID");
+            }
+        }
+
 #endif // NDEBUG
 
     } /* namespace debug */


### PR DESCRIPTION
Added ability to parse `TDH_INTYPE_SID` and `TDH_INTYPE_WBEMSID` types.
I made two major assumptions that if you don't agree with I can fix:

1) In `TDH_INTYPE_WBEMSID` we only care about the SID part, not the `TOKEN_USER` - This is based upon this MSDN example, which also only pulls out the SID: https://docs.microsoft.com/en-us/windows/win32/etw/using-tdhgetproperty-to-consume-event-data. Also as this type is depracted, and you're meant to only use `TDH_INTYPE_SID` This meant we can 'decode' both TDHs to the same struct.

2) I store the string of the SID instead of the bytes. As SIDs are variable-length, this seemed like the easiest way to deal with them, as we can have the string on the stack instead of allocating and copying the varaible-length bytes.
