### PR TITLE
Bring back process api for trace

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.9</version>
+        <version>4.1.10</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Added support for reading container ID extended data in managed API.</releaseNotes>
+        <releaseNotes>Reinstate process API for traces that skips implicit opening of traces.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.9</version>
+        <version>4.1.10</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Added support for reading container ID extended data in managed API.</releaseNotes>
+        <releaseNotes>Reinstate process API for traces that skips implicit opening of traces.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -63,6 +63,14 @@ namespace krabs { namespace details {
         EVENT_TRACE_LOGFILE open();
 
         /**
+        * <summary>
+        * Starts processing the ETW trace identified by the info in the trace type.
+        * open() needs to called for this to work first.
+        * </summary>
+        */
+        void process();
+
+        /**
          * <summary>
          * Queries the ETW trace identified by the info in the trace type.
          * </summary>
@@ -163,6 +171,12 @@ namespace krabs { namespace details {
         register_trace();
         enable_providers();
         return open_trace();
+    }
+
+    template <typename T>
+    void trace_manager<T>::process()
+    {
+        process_trace();
     }
 
     template <typename T>

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -183,10 +183,17 @@ namespace krabs {
 
         /**
         * <summary>
-        * This is an alias for start().
+        * Start processing events for an already opened session.
         * </summary>
+        * <example>
+        *    krabs::trace trace;
+        *    krabs::guid id(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
+        *    provider<> powershell(id);
+        *    trace.enable(powershell);
+        *    trace.open();
+        *    trace.process();
+        * </example>
         */
-        [[deprecated("use start() instead")]]
         void process();
 
         /**
@@ -330,7 +337,10 @@ namespace krabs {
     template <typename T>
     void trace<T>::process()
     {
-        trace<T>::start();
+        eventsHandled_ = 0;
+
+        details::trace_manager<trace> manager(*this);
+        manager.process();
     }
 
     template <typename T>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.9</version>
+        <version>4.1.10</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Added support for reading container ID extended data in managed API.</releaseNotes>
+        <releaseNotes>Reinstate process API for traces that skips implicit opening of traces.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>


### PR DESCRIPTION
The separate process API allows more fine grained control in multi threaded scenarios as there is no possibility of an implicit opening of the trace.