### PR TITLE
fixed schema event_name parsing

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.10</version>
+        <version>4.1.11</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Reinstate process API for traces that skips implicit opening of traces.</releaseNotes>
+        <releaseNotes>Fixed parsing event name and added ability to parse opcode name.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.10</version>
+        <version>4.1.11</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Reinstate process API for traces that skips implicit opening of traces.</releaseNotes>
+        <releaseNotes>Fixed parsing event name and added ability to parse opcode name.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabs/krabs/perfinfo_groupmask.hpp
+++ b/krabs/krabs/perfinfo_groupmask.hpp
@@ -184,8 +184,9 @@ typedef struct _EVENT_TRACE_GROUPMASK_INFORMATION {
     PERFINFO_GROUPMASK EventTraceGroupMasks;
 } EVENT_TRACE_GROUPMASK_INFORMATION, * PEVENT_TRACE_GROUPMASK_INFORMATION;
 
+#ifndef _WINTERNL_
+
 typedef enum _SYSTEM_INFORMATION_CLASS {
-    SystemPerformanceTraceInformation = 0x1f
 } SYSTEM_INFORMATION_CLASS;
 
 typedef LONG NTSTATUS;
@@ -197,8 +198,12 @@ extern "C" NTSTATUS NTAPI NtQuerySystemInformation(
     _Out_opt_ PULONG ReturnLength
 );
 
+#endif // _WINTERNL_
+
 extern "C" NTSTATUS NTAPI NtSetSystemInformation(
     _In_ SYSTEM_INFORMATION_CLASS SystemInformationClass,
     _In_reads_bytes_opt_(SystemInformationLength) PVOID SystemInformation,
     _In_ ULONG SystemInformationLength
 );
+
+constexpr auto SystemPerformanceTraceInformation{ static_cast<SYSTEM_INFORMATION_CLASS>(0x1f) };

--- a/krabs/krabs/schema.hpp
+++ b/krabs/krabs/schema.hpp
@@ -248,9 +248,20 @@ namespace krabs {
 
     inline const wchar_t *schema::event_name() const
     {
-        return reinterpret_cast<const wchar_t*>(
-            reinterpret_cast<const char*>(pSchema_) +
-            pSchema_->EventNameOffset);
+        /*
+        EventNameOffset will be 0 if the event does not have an assigned name or
+        if this event is decoded on a system that does not support decoding
+        manifest event names. Event name decoding is supported on Windows
+        10 Fall Creators Update (2017) and later.
+        */
+        if (pSchema_->EventNameOffset != 0) {
+            return reinterpret_cast<const wchar_t*>(
+                reinterpret_cast<const char*>(pSchema_) +
+                pSchema_->EventNameOffset);
+        }
+        else {
+            return L"";
+        }
     }
 
     inline const wchar_t *schema::task_name() const

--- a/krabs/krabs/schema.hpp
+++ b/krabs/krabs/schema.hpp
@@ -82,6 +82,20 @@ namespace krabs {
 
         /*
          * <summary>
+         * Returns the name of an opcode via its schema.
+         * </summary>
+         * <example>
+         *    void on_event(const EVENT_RECORD &record, const krabs::trace_context &trace_context)
+         *    {
+         *        krabs::schema schema(record, trace_context.schema_locator);
+         *        std::wstring name = krabs::opcode_name(schema);
+         *    }
+         * </example>
+         */
+        const wchar_t* opcode_name() const;
+
+        /*
+         * <summary>
          * Returns the taskname of an event via its schema.
          * </summary>
          * <example>
@@ -226,6 +240,7 @@ namespace krabs {
 
     private:
         friend std::wstring event_name(const schema &);
+        friend std::wstring opcode_name(const schema &);
         friend std::wstring task_name(const schema &);
         friend DECODING_SOURCE decoding_source(const schema &);
         friend std::wstring provider_name(const schema &);
@@ -273,6 +288,21 @@ namespace krabs {
             return reinterpret_cast<const wchar_t*>(
                 reinterpret_cast<const char*>(pSchema_) +
                 pSchema_->EventNameOffset);
+        }
+        else {
+            return L"";
+        }
+    }
+
+    inline const wchar_t* schema::opcode_name() const
+    {
+        /*
+        In WPP Traces OpcodeName is not used
+        */
+        if (pSchema_->OpcodeNameOffset != 0) {
+            return reinterpret_cast<const wchar_t*>(
+                reinterpret_cast<const char*>(pSchema_) +
+                pSchema_->OpcodeNameOffset);
         }
         else {
             return L"";

--- a/krabs/krabs/schema.hpp
+++ b/krabs/krabs/schema.hpp
@@ -250,7 +250,7 @@ namespace krabs {
     {
         return reinterpret_cast<const wchar_t*>(
             reinterpret_cast<const char*>(pSchema_) +
-            pSchema_->OpcodeNameOffset);
+            pSchema_->EventNameOffset);
     }
 
     inline const wchar_t *schema::task_name() const

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.10</version>
+        <version>4.1.11</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Reinstate process API for traces that skips implicit opening of traces.</releaseNotes>
+        <releaseNotes>Fixed parsing event name and added ability to parse opcode name.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>


### PR DESCRIPTION
Fixes two things:
1) `event_name` was using at `OpcodeNameOffset` instead of `EventNameOffset`
2) `EventNameOffset` can be 0, in which case it doesn't have an event name