### PR TITLE
Enable parsing TDH_IN_POINTER types

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
@@ -351,6 +351,53 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
 #pragma endregion
 
+#pragma region Pointer
+        /// <summary>
+        /// Get a Pointer type from the from the specified property name
+        /// </summary>
+        /// <param name="name">property name</param>
+        /// <returns>the IntPtr value associated with the specified property</returns>
+        virtual IntPtr^ GetPointer(String^ name)
+        {
+            const auto& addr = GetValue<krabs::pointer>(name);
+            return ConvertToPointer(addr);
+        }
+
+        /// <summary>
+        /// Get a Pointer from the specified property name or returns
+        /// the specified default value.
+        /// </summary>
+        /// <param name="name">property name</param>
+        /// <param name="defaultValue">the default value to return if the property lookup fails</param>
+        /// <returns>the SocketAddress value associated with the specified property or the specified default value</returns>
+        virtual IntPtr^ GetPointer(String^ name, IntPtr^ defaultValue)
+        {
+            IntPtr^ addr;
+
+            if (TryGetPointer(name, addr))
+                return addr;
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// Attempt to get a Security Identifier (SID) from the specified property name.
+        /// </summary>
+        /// <param name="name">property name</param>
+        /// <param name="result">the resulting SocketAddress</param>
+        /// <returns>true if fetching the SocketAddress succeeded, false otherwise</returns>
+        virtual bool TryGetPointer(String^ name, [Out] IntPtr^% result)
+        {
+            krabs::pointer addr;
+            bool success = TryGetValue(name, addr);
+
+            if (success)
+                result = ConvertToPointer(addr);
+
+            return success;
+        }
+#pragma endregion
+
 #pragma region DateTime
         /// <summary>
         /// Get a DateTime from the specified property name.
@@ -795,6 +842,12 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         {
             auto managed_string = gcnew String(addr.sid_string.c_str());
             auto managed = gcnew SecurityIdentifier(managed_string);
+            return managed;
+        }
+
+        IntPtr^ ConvertToPointer(const krabs::pointer& addr)
+        {
+            auto managed = gcnew IntPtr(reinterpret_cast<long long>(addr.wild_reference));
             return managed;
         }
 

--- a/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
@@ -356,7 +356,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// Get a Pointer type from the from the specified property name
         /// </summary>
         /// <param name="name">property name</param>
-        /// <returns>the IntPtr value associated with the specified property</returns>
+        /// <returns>The IntPtr associated with the specified property</returns>
         virtual IntPtr^ GetPointer(String^ name)
         {
             const auto& addr = GetValue<krabs::pointer>(name);
@@ -369,7 +369,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// </summary>
         /// <param name="name">property name</param>
         /// <param name="defaultValue">the default value to return if the property lookup fails</param>
-        /// <returns>the SocketAddress value associated with the specified property or the specified default value</returns>
+        /// <returns>the IntPtr value associated with the specified property or the specified default value</returns>
         virtual IntPtr^ GetPointer(String^ name, IntPtr^ defaultValue)
         {
             IntPtr^ addr;
@@ -381,11 +381,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
 
         /// <summary>
-        /// Attempt to get a Security Identifier (SID) from the specified property name.
+        /// Attempt to get a Pointer from the specified property name.
         /// </summary>
         /// <param name="name">property name</param>
-        /// <param name="result">the resulting SocketAddress</param>
-        /// <returns>true if fetching the SocketAddress succeeded, false otherwise</returns>
+        /// <param name="result">the resulting IntPtr</param>
+        /// <returns>true if fetching the IntPtr succeeded, false otherwise</returns>
         virtual bool TryGetPointer(String^ name, [Out] IntPtr^% result)
         {
             krabs::pointer addr;
@@ -847,7 +847,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
         IntPtr^ ConvertToPointer(const krabs::pointer& addr)
         {
-            auto managed = gcnew IntPtr(reinterpret_cast<long long>(addr.wild_reference));
+            auto managed = gcnew IntPtr(static_cast<long long>(addr.address));
             return managed;
         }
 

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.11</version>
+        <version>4.1.12</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Fixed parsing event name and added ability to parse opcode name.</releaseNotes>
+        <releaseNotes>Added ability to parse TDH_INTYPE_POINTER data</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.11</version>
+        <version>4.1.12</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Fixed parsing event name and added ability to parse opcode name.</releaseNotes>
+        <releaseNotes>Added ability to parse TDH_INTYPE_POINTER data</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabs/krabs/parse_types.hpp
+++ b/krabs/krabs/parse_types.hpp
@@ -253,6 +253,42 @@ namespace krabs {
     private:
     };
 
+    /**
+    * <summary>
+    * Used to handle parsing of POINTER types
+    */
+    struct pointer {
+        // Make the reference const and call it wild,
+        // As any attempt to derefernce or alter what it points to
+        // would be very undefined behaviour, as it
+        // is unlikley it is pointing to inside our process' memory
+        const void* wild_reference;
+
+        static pointer from_bytes(const BYTE* bytes, size_t size_in_bytes)
+        {
+            pointer pt;
+
+            // If 32-Bit, first parse as a uint32
+            // Then we can 'cast' that as pointer
+            if (size_in_bytes == sizeof(uint32_t)) {
+                uint64_t tmp = *(uint32_t*)bytes;
+                pt.wild_reference = (void*)(tmp);
+            }
+            else if (size_in_bytes == sizeof(uint64_t)) {
+                uint64_t tmp = *(uint64_t*)bytes;
+                pt.wild_reference = (void*)tmp;
+            }
+            else {
+                throw std::runtime_error(
+                    "Failed to get a POINTER from a property");
+            }
+
+            return pt;
+        }
+
+    private:
+    };
+
 
     /**
      * <summary>

--- a/krabs/krabs/parse_types.hpp
+++ b/krabs/krabs/parse_types.hpp
@@ -255,28 +255,27 @@ namespace krabs {
 
     /**
     * <summary>
-    * Used to handle parsing of POINTER types
+    * Used to handle parsing of Pointer Address types.
+    * </summary>
     */
     struct pointer {
-        // Make the reference const and call it wild,
-        // As any attempt to derefernce or alter what it points to
-        // would be very undefined behaviour, as it
-        // is unlikley it is pointing to inside our process' memory
-        const void* wild_reference;
+        /**
+        * We store the pointer as an uint64_t, as it is highly unlikley
+        * to be pointing to somewhere accessible to our process
+        */
+        uint64_t address;
 
         static pointer from_bytes(const BYTE* bytes, size_t size_in_bytes)
         {
             pointer pt;
 
             // If 32-Bit, first parse as a uint32
-            // Then we can 'cast' that as pointer
+            // Then we can 'cast' that to our uint64_t
             if (size_in_bytes == sizeof(uint32_t)) {
-                uint64_t tmp = *(uint32_t*)bytes;
-                pt.wild_reference = (void*)(tmp);
+                pt.address = *reinterpret_cast<const uint32_t*>(bytes);
             }
             else if (size_in_bytes == sizeof(uint64_t)) {
-                uint64_t tmp = *(uint64_t*)bytes;
-                pt.wild_reference = (void*)tmp;
+                pt.address = *reinterpret_cast<const uint64_t*>(bytes);
             }
             else {
                 throw std::runtime_error(

--- a/krabs/krabs/parser.hpp
+++ b/krabs/krabs/parser.hpp
@@ -367,14 +367,14 @@ namespace krabs {
         //
         //      The size of the TOKEN_USER structure differs
         //      depending on whether the events were generated on a 32 - bit
-        //      or 64 - bit architecture.Also the structure is aligned
+        //      or 64 - bit architecture. Also the structure is aligned
         //      on an 8 - byte boundary, so its size is 8 bytes on a
         //      32 - bit computer and 16 bytes on a 64 - bit computer.
         //      Doubling the pointer size handles both cases.
-        //
-        // So as we are 64-bit, this means we the SID starts at
-        // 16 bytes into the data
-        static const int sid_start = 16;
+        ULONG sid_start = 16;
+        if (EVENT_HEADER_FLAG_32_BIT_HEADER == (schema_.record_.EventHeader.Flags & EVENT_HEADER_FLAG_32_BIT_HEADER)) {
+            sid_start = 8;
+        }
         switch (InType) {
         case TDH_INTYPE_SID:
             return sid::from_bytes(propInfo.pPropertyIndex_, propInfo.length_);
@@ -389,6 +389,17 @@ namespace krabs {
         default:
             throw std::runtime_error("SID was not a SID or WBEMSID");
         }
+    }
+
+    template<>
+    inline pointer parser::parse<pointer>(const std::wstring& name)
+    {
+        auto propInfo = find_property(name);
+        throw_if_property_not_found(propInfo);
+
+        krabs::debug::assert_valid_assignment<pointer>(name, propInfo);
+
+        return pointer::from_bytes(propInfo.pPropertyIndex_, propInfo.length_);
     }
 
     // view_of

--- a/krabs/krabs/tdh_helpers.hpp
+++ b/krabs/krabs/tdh_helpers.hpp
@@ -186,11 +186,23 @@ namespace krabs {
         inline void assert_valid_assignment<sid>(
             const std::wstring&, const property_info& info)
         {
-            auto InType = info.pEventPropertyInfo_->nonStructType.InType;
+            auto inType = info.pEventPropertyInfo_->nonStructType.InType;
 
-            if (InType != TDH_INTYPE_WBEMSID && InType != TDH_INTYPE_SID) {
+            if (inType != TDH_INTYPE_WBEMSID && inType != TDH_INTYPE_SID) {
                 throw std::runtime_error(
                     "Requested a SID but was neither a SID nor WBEMSID");
+            }
+        }
+
+        template <>
+        inline void assert_valid_assignment<pointer>(
+            const std::wstring&, const property_info& info)
+        {
+            auto inType = info.pEventPropertyInfo_->nonStructType.InType;
+
+            if (inType != TDH_INTYPE_POINTER) {
+                throw std::runtime_error(
+                    "Requested a POINTER from property that is not one");
             }
         }
 

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.11</version>
+        <version>4.1.12</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Fixed parsing event name and added ability to parse opcode name.</releaseNotes>
+        <releaseNotes>Added ability to parse TDH_INTYPE_POINTER data</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>


### PR DESCRIPTION
This merge attempts to enable easy parsing of `TDH_INTYPE_POINTER`, whilst attempting to protect developers from poor decisions.

Whilst `TDH_INTYPE_POINTER` are Pointers, the likelihood the address is accessible to the trace process is extremely low, and at times might even be pointers to kernel memory.
As such I feel any solution needs to make it clear to developers using Krabs that while it is OK to get the pointer for printing or comparison purposes, any attempt at de-referencing it will probably blow up in their face.

If we just enable `.parse<void*>()` it as a `void*`, then a dev could blindly do:
```c
std::uint32_t* pFileobj = (std::uint32_t*)parser.parse<void*>(L"FileObject");

// This will either explode (esp. if a kernel pointer), or point to something else entirely
std::uint32_t fileobj = *pFileobj ;

// If the above didn't explode, then this could be altering something else
fileobj += 5;
```

That's why my attempt at a solution opted to create a new struct type `pointer`, with the reference named `wild_reference`. This makes the developer have to write:
```c
krabs::pointer krabs_fileobj = parser.parse<krabs::pointer>(L"FileObject");

// Have to use 'wild' reference
// Also const prevents alteration
const std::uint32_t* pFileobj_wild = (const std::uint32_t*)(krabs_fileobj.wild_reference);

// This will still go boom, but we gave them a bit a warning.
const std::uint32_t fileobj = *pFileobj_wild;
```

We could also use `dangerous` instead of `wild` if you feel that would be better.

Another option would make `krabs::pointer.wild_reference` an integer instead of a `void*`, make it even more explicit that the pointer isn't for de-referencing. 
