### PR TITLE
Remove krabs.cpp reference and add missing header

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.12</version>
+        <version>4.1.13</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.12</version>
+        <version>4.1.13</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/build/native/krabsetw.targets
+++ b/build/native/krabsetw.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup>
     <ClCompile>
@@ -7,12 +7,5 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\krabs.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <SDLCheck>False</SDLCheck>
-      <ExceptionHandling>Async</ExceptionHandling>
-      <PreprocessorDefinitions>;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
   </ItemGroup>
 </Project>

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
@@ -23,6 +23,7 @@
         <file src="krabs\krabs\filtering\predicates.hpp" target="lib\native\include\krabs\filtering\predicates.hpp" />
         <file src="krabs\krabs\filtering\view_adapters.hpp" target="lib\native\include\krabs\filtering\view_adapters.hpp" />
         <file src="krabs\krabs\testing\event_filter_proxy.hpp" target="lib\native\include\krabs\testing\event_filter_proxy.hpp" />
+        <file src="krabs\krabs\testing\extended_data_builder.hpp" target="lib\native\include\krabs\testing\extended_data_builder.hpp" />
         <file src="krabs\krabs\testing\filler.hpp" target="lib\native\include\krabs\testing\filler.hpp" />
         <file src="krabs\krabs\testing\proxy.hpp" target="lib\native\include\krabs\testing\proxy.hpp" />
         <file src="krabs\krabs\testing\record_builder.hpp" target="lib\native\include\krabs\testing\record_builder.hpp" />

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.12</version>
+        <version>4.1.13</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>


### PR DESCRIPTION
closes #133 

Right now the [upstream version](https://www.nuget.org/packages/Microsoft.O365.Security.Krabsetw/4.1.12) is broken.