### PR TITLE
Ignore struct padding when computing std::hash<schema_key> 

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.13</version>
+        <version>4.1.14</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Added ability to parse TDH_INTYPE_POINTER data</releaseNotes>
+        <releaseNotes>Fix schema caching issue that could result in a memory leak</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.13</version>
+        <version>4.1.14</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Added ability to parse TDH_INTYPE_POINTER data</releaseNotes>
+        <releaseNotes>Fix schema caching issue that could result in a memory leak</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabs/krabs/guid.hpp
+++ b/krabs/krabs/guid.hpp
@@ -309,4 +309,21 @@ namespace std
 
         return { managed.get() };
     }
+
+    template<>
+    struct std::hash<krabs::guid>
+    {
+        size_t operator()(const krabs::guid& guid) const
+        {
+            const char* guidBytes = (const char*)&guid;
+            size_t h = 2166136261;
+
+            for (auto i = 0; i < sizeof(guid); ++i)
+            {
+                h ^= (h << 5) + (h >> 2) + guidBytes[i];
+            }
+
+            return h;
+        }
+    };
 }

--- a/krabs/krabs/guid.hpp
+++ b/krabs/krabs/guid.hpp
@@ -315,9 +315,10 @@ namespace std
     {
         size_t operator()(const krabs::guid& guid) const
         {
-            const char* guidBytes = (const char*)&guid;
+            // Shift-Add-XOR hash starts with this prime number
             size_t h = 2166136261;
 
+            const char* guidBytes = (const char*)&guid;
             for (auto i = 0; i < sizeof(guid); ++i)
             {
                 h ^= (h << 5) + (h >> 2) + guidBytes[i];

--- a/krabs/krabs/schema_locator.hpp
+++ b/krabs/krabs/schema_locator.hpp
@@ -29,7 +29,6 @@ namespace krabs {
      * Type used as the key for cache lookup in a schema_locator.
      * </summary>
      */
-    #pragma pack(push, 1) // Ref: https://github.com/microsoft/krabsetw/issues/139
     struct schema_key
     {
         guid      provider;
@@ -56,7 +55,6 @@ namespace krabs {
 
         bool operator!=(const schema_key &rhs) const { return !(*this == rhs); }
     };
-    #pragma pack(pop)
 }
 
 namespace std {
@@ -72,13 +70,13 @@ namespace std {
         size_t operator()(const krabs::schema_key &key) const
         {
             // Shift-Add-XOR hash - good enough for the small sets we deal with
-            const char* p = (const char*)&key;
             size_t h = 2166136261;
 
-            for(auto i = 0; i < sizeof(key); ++i)
-            {
-                h ^= (h << 5) + (h >> 2) + p[i];
-            }
+            h ^= (h << 5) + (h >> 2) + std::hash<krabs::guid>()(key.provider);
+            h ^= (h << 5) + (h >> 2) + key.id;
+            h ^= (h << 5) + (h >> 2) + key.opcode;
+            h ^= (h << 5) + (h >> 2) + key.version;
+            h ^= (h << 5) + (h >> 2) + key.level;
 
             return h;
         }

--- a/krabs/krabs/schema_locator.hpp
+++ b/krabs/krabs/schema_locator.hpp
@@ -29,6 +29,7 @@ namespace krabs {
      * Type used as the key for cache lookup in a schema_locator.
      * </summary>
      */
+    #pragma pack(push, 1) // Ref: https://github.com/microsoft/krabsetw/issues/139
     struct schema_key
     {
         guid      provider;
@@ -55,6 +56,7 @@ namespace krabs {
 
         bool operator!=(const schema_key &rhs) const { return !(*this == rhs); }
     };
+    #pragma pack(pop)
 }
 
 namespace std {

--- a/krabs/krabs/testing/record_builder.hpp
+++ b/krabs/krabs/testing/record_builder.hpp
@@ -82,6 +82,7 @@ namespace krabs { namespace testing {
             size_t id,
             size_t version,
             size_t opcode = 0,
+            size_t level = 0,
             bool trim_string_null_terminator = false);
 
         /**
@@ -150,8 +151,6 @@ namespace krabs { namespace testing {
          */
         EVENT_HEADER &header();
 
-    private:
-
         /**
          * <summary>
          *   Fills an EVENT_RECORD with the info necessary to grab its schema
@@ -159,6 +158,8 @@ namespace krabs { namespace testing {
          * </summary>
          */
          EVENT_RECORD create_stub_record() const;
+
+    private:
 
         /**
          * <summary>
@@ -178,6 +179,7 @@ namespace krabs { namespace testing {
         const size_t id_;
         const size_t version_;
         const size_t opcode_;
+        const size_t level_;
         EVENT_HEADER header_;
         std::vector<record_property_thunk> properties_;
         bool trim_string_null_terminator_;
@@ -211,17 +213,20 @@ namespace krabs { namespace testing {
         size_t id,
         size_t version,
         size_t opcode,
+        size_t level,
         bool trim_string_null_terminator)
     : providerId_(providerId)
     , id_(id)
     , version_(version)
     , opcode_(opcode)
+    , level_(level)
     , trim_string_null_terminator_(trim_string_null_terminator)
     {
         ZeroMemory(&header_, sizeof(EVENT_HEADER));
         header_.EventDescriptor.Id      = static_cast<USHORT>(id_);
         header_.EventDescriptor.Version = static_cast<UCHAR>(version_);
         header_.EventDescriptor.Opcode  = static_cast<UCHAR>(opcode_);
+        header_.EventDescriptor.Level   = static_cast<UCHAR>(level_);
         memcpy(&header_.ProviderId, (const GUID *)&providerId_, sizeof(GUID));
     }
 

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.13</version>
+        <version>4.1.14</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Added ability to parse TDH_INTYPE_POINTER data</releaseNotes>
+        <releaseNotes>Fix schema caching issue that could result in a memory leak</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>

--- a/tests/krabstests/krabstests.vcxproj
+++ b/tests/krabstests/krabstests.vcxproj
@@ -204,6 +204,7 @@
     <ClCompile Include="test_guid_parser.cpp" />
     <ClCompile Include="test_parser.cpp" />
     <ClCompile Include="test_parse_types.cpp" />
+    <ClCompile Include="test_schema_key.cpp" />
     <ClCompile Include="test_trace_properties.cpp" />
     <ClCompile Include="test_user_providers.cpp" />
     <ClCompile Include="test_record_builder.cpp" />

--- a/tests/krabstests/krabstests.vcxproj
+++ b/tests/krabstests/krabstests.vcxproj
@@ -201,6 +201,7 @@
     <ClCompile Include="test_collection_view.cpp" />
     <ClCompile Include="test_event_callbacks.cpp" />
     <ClCompile Include="test_filter.cpp" />
+    <ClCompile Include="test_guid.cpp" />
     <ClCompile Include="test_guid_parser.cpp" />
     <ClCompile Include="test_parser.cpp" />
     <ClCompile Include="test_parse_types.cpp" />

--- a/tests/krabstests/krabstests.vcxproj.filters
+++ b/tests/krabstests/krabstests.vcxproj.filters
@@ -49,5 +49,8 @@
     <ClCompile Include="test_guid_parser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="test_schema_key.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/krabstests/krabstests.vcxproj.filters
+++ b/tests/krabstests/krabstests.vcxproj.filters
@@ -52,5 +52,8 @@
     <ClCompile Include="test_schema_key.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="test_guid.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/krabstests/test_guid.cpp
+++ b/tests/krabstests/test_guid.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "CppUnitTest.h"
+#include <krabs.hpp>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace krabstests
+{
+    TEST_CLASS(test_guid)
+    {
+    private:
+        const krabs::guid guid1a;
+        const krabs::guid guid1b;
+        const krabs::guid guid2;
+        const std::hash<krabs::guid> hash;
+
+    public:
+        test_guid() :
+            guid1a(L"{88154140-f63a-4028-8826-b0028614d67b}"),
+            guid1b(L"{88154140-f63a-4028-8826-b0028614d67b}"),
+            guid2(L"{41ee9f36-5a4e-4138-bc0e-2141a84eb089}"),
+            hash()
+        {
+        }
+
+        TEST_METHOD(should_be_equal_when_identical)
+        {
+            Assert::IsTrue(guid1a == guid1b);
+        }
+        TEST_METHOD(should_hash_same_when_identical)
+        {
+            Assert::IsTrue(hash(guid1a) == hash(guid1b));
+        }
+        TEST_METHOD(should_not_be_equal_when_different)
+        {
+            Assert::IsFalse(guid1a == guid2);
+        }
+        TEST_METHOD(should_not_hash_same_when_different)
+        {
+            Assert::IsFalse(hash(guid1a) == hash(guid2));
+        }
+    };
+}

--- a/tests/krabstests/test_parser.cpp
+++ b/tests/krabstests/test_parser.cpp
@@ -129,7 +129,7 @@ namespace krabstests
 
             krabs::guid httpsys(L"{dd5ef90a-6398-47a4-ad34-4dcecdef795f}");
             // httpsys: parse event
-            krabs::testing::record_builder builder(httpsys, krabs::id(2), 0U, 12, true);
+            krabs::testing::record_builder builder(httpsys, krabs::id(2), 0U, 12, 1, true);
             builder.add_properties()
                 (L"Url", expectedUrl);
 
@@ -148,7 +148,7 @@ namespace krabstests
 
             krabs::guid httpsys(L"{dd5ef90a-6398-47a4-ad34-4dcecdef795f}");
             // httpsys: parse event
-            krabs::testing::record_builder builder(httpsys, krabs::id(2), 0U, 12, true);
+            krabs::testing::record_builder builder(httpsys, krabs::id(2), 0U, 12, 1, true);
             builder.add_properties()
                 (L"Url", expectedUrl);
 

--- a/tests/krabstests/test_schema_key.cpp
+++ b/tests/krabstests/test_schema_key.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "CppUnitTest.h"
+#include <krabs.hpp>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace krabstests
+{
+    TEST_CLASS(test_schema_key)
+    {
+    public:
+        TEST_METHOD(operator_equals)
+        {
+            const EVENT_RECORD eventRecord = {};
+            const krabs::schema_key key1{ eventRecord };
+            const krabs::schema_key key2{ eventRecord };
+
+            Assert::IsTrue(key1 == key2);
+        }
+        TEST_METHOD(hash_specialization)
+        {
+            const EVENT_RECORD eventRecord = {};
+            const krabs::schema_key key1{ eventRecord };
+            const krabs::schema_key key2{ eventRecord };
+
+            const std::hash<krabs::schema_key> hash;
+
+            // When a defect is present, this may only fail in Release builds
+            // Ref: https://github.com/microsoft/krabsetw/issues/139
+            Assert::IsTrue(hash(key1) == hash(key2));
+        }
+    };
+}

--- a/tests/krabstests/test_schema_key.cpp
+++ b/tests/krabstests/test_schema_key.cpp
@@ -10,8 +10,33 @@ namespace krabstests
 {
     TEST_CLASS(test_schema_key)
     {
+    private:
+        const krabs::guid provider1;
+        const krabs::guid provider2;
+        const std::hash<krabs::schema_key> hash;
+
+        krabs::schema_key GetKeyForRecord(
+            const krabs::guid& providerId,
+            const size_t id,
+            const size_t version,
+            const size_t opcode,
+            const size_t level)
+        {
+            krabs::testing::record_builder builder(providerId, id, version, opcode, level);
+            auto record = builder.create_stub_record();
+
+            return krabs::schema_key{ EVENT_RECORD(record) };
+        }
+
     public:
-        TEST_METHOD(operator_equals)
+        test_schema_key() :
+            provider1(L"{88154140-f63a-4028-8826-b0028614d67b}"),
+            provider2(L"{41ee9f36-5a4e-4138-bc0e-2141a84eb089}"),
+            hash()
+        {
+        }
+
+        TEST_METHOD(should_be_equal_when_uninitialized)
         {
             const EVENT_RECORD eventRecord = {};
             const krabs::schema_key key1{ eventRecord };
@@ -19,17 +44,99 @@ namespace krabstests
 
             Assert::IsTrue(key1 == key2);
         }
-        TEST_METHOD(hash_specialization)
+        TEST_METHOD(should_hash_same_when_uninitialized)
         {
             const EVENT_RECORD eventRecord = {};
             const krabs::schema_key key1{ eventRecord };
             const krabs::schema_key key2{ eventRecord };
 
-            const std::hash<krabs::schema_key> hash;
-
             // When a defect is present, this may only fail in Release builds
             // Ref: https://github.com/microsoft/krabsetw/issues/139
             Assert::IsTrue(hash(key1) == hash(key2));
+        }
+        TEST_METHOD(should_be_equal_when_identical_property_values)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+
+            Assert::IsTrue(key1 == key2);
+        }
+        TEST_METHOD(should_hash_same_when_identical_property_values)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+
+            Assert::IsTrue(hash(key1) == hash(key2));
+        }
+        TEST_METHOD(should_not_be_equal_when_providerid_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider2, 1, 2, 3, 4);
+
+            Assert::IsFalse(key1 == key2);
+        }
+        TEST_METHOD(should_not_hash_same_when_providerid_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider2, 1, 2, 3, 4);
+
+            Assert::IsFalse(hash(key1) == hash(key2));
+        }
+        TEST_METHOD(should_not_be_equal_when_id_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 2, 2, 3, 4);
+
+            Assert::IsFalse(key1 == key2);
+        }
+        TEST_METHOD(should_not_hash_same_when_id_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 2, 2, 3, 4);
+
+            Assert::IsFalse(hash(key1) == hash(key2));
+        }
+        TEST_METHOD(should_not_be_equal_when_version_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 3, 3, 4);
+
+            Assert::IsFalse(key1 == key2);
+        }
+        TEST_METHOD(should_not_hash_same_when_version_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 3, 3, 4);
+
+            Assert::IsFalse(hash(key1) == hash(key2));
+        }
+        TEST_METHOD(should_not_be_equal_when_opcode_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 2, 4, 4);
+
+            Assert::IsFalse(key1 == key2);
+        }
+        TEST_METHOD(should_not_hash_same_when_opcode_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 2, 4, 4);
+
+            Assert::IsFalse(hash(key1) == hash(key2));
+        }
+        TEST_METHOD(should_not_be_equal_when_level_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 2, 3, 5);
+
+            Assert::IsFalse(key1 == key2);
+        }
+        TEST_METHOD(should_not_hash_same_when_level_differs)
+        {
+            auto key1 = GetKeyForRecord(provider1, 1, 2, 3, 4);
+            auto key2 = GetKeyForRecord(provider1, 1, 2, 3, 5);
+
+            Assert::IsFalse(hash(key1) == hash(key2));
         }
     };
 }


### PR DESCRIPTION
Fixes #139 