### PR TITLE
Fix parsing of boolean type

### DIFF
--- a/krabs/krabs/parser.hpp
+++ b/krabs/krabs/parser.hpp
@@ -267,6 +267,18 @@ namespace krabs {
         return *(T*)propInfo.pPropertyIndex_;
     }
 
+    template<>
+    inline bool parser::parse<bool>(const std::wstring& name)
+    {
+        auto propInfo = find_property(name);
+        throw_if_property_not_found(propInfo);
+
+        krabs::debug::assert_valid_assignment<bool>(name, propInfo);
+
+        // Boolean in ETW is 4 bytes long
+        return static_cast<bool>(*(unsigned*)propInfo.pPropertyIndex_);
+    }
+
     template <>
     inline std::wstring parser::parse<std::wstring>(const std::wstring &name)
     {

--- a/krabs/krabs/perfinfo_groupmask.hpp
+++ b/krabs/krabs/perfinfo_groupmask.hpp
@@ -13,11 +13,10 @@
 #define PERF_NUM_MASKS          8
 
 typedef ULONG PERFINFO_MASK;
-#ifndef _PHNT_H
+
 typedef struct _PERFINFO_GROUPMASK {
     ULONG Masks[PERF_NUM_MASKS];
 } PERFINFO_GROUPMASK, *PPERFINFO_GROUPMASK;
-#endif // _PHNT_H
 
 #define PERF_GET_MASK_INDEX(GM) (((GM) & PERF_MASK_INDEX) >> 29)
 #define PERF_GET_MASK_GROUP(GM) ((GM) & PERF_MASK_GROUP)
@@ -152,7 +151,6 @@ typedef struct _PERFINFO_GROUPMASK {
 #define PERF_CLUSTER_OFF        0xE0000001
 #define PERF_MEMORY_CONTROL     0xE0000002
 
-#ifndef _PHNT_H
 
 // TraceQueryInformation wasn't introduced until Windows 8, so we need to use
 // NtQuerySystemInformation instead in order to maintain support for Windows 7.
@@ -209,5 +207,3 @@ extern "C" NTSTATUS NTAPI NtSetSystemInformation(
 );
 
 constexpr auto SystemPerformanceTraceInformation{ static_cast<SYSTEM_INFORMATION_CLASS>(0x1f) };
-
-#endif // _PHNT_H

--- a/krabs/krabs/tdh_helpers.hpp
+++ b/krabs/krabs/tdh_helpers.hpp
@@ -206,6 +206,18 @@ namespace krabs {
             }
         }
 
+        template <>
+        inline void assert_valid_assignment<bool>(
+            const std::wstring&, const property_info& info)
+        {
+            auto inType = info.pEventPropertyInfo_->nonStructType.InType;
+
+            if (inType != TDH_INTYPE_BOOLEAN) {
+                throw std::runtime_error(
+                    "Requested a BOOLEAN from property that is not one");
+            }
+        }
+
 #endif // NDEBUG
 
     } /* namespace debug */


### PR DESCRIPTION
Exception "Property size doesn't match requested size" rise if we try to query **bool** value from **TDH_INTYPE_BOOLEAN** field.
Example of code:
`if (prop.type() == TDH_INTYPE_BOOLEAN)
    val = parser.parse<bool>(prop.name());`

Note, if we try to query TDH_INTYPE_BOOLEAN as BOOL (or any other 4-byte type) function parse() rise another exception "Attempt to read property 'XXX' type BOOLEAN as INT32"