### PR TITLE
catch invalid_parameter in register_trace()

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.18</version>
+        <version>4.1.19</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.18</version>
+        <version>4.1.19</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -305,6 +305,12 @@ namespace krabs { namespace details {
                 // StartTrace() actually sets this to 0 on failure
                 trace_.registrationHandle_ = INVALID_PROCESSTRACE_HANDLE;
             }
+            catch (invalid_parameter) {
+                (void)open_trace();
+                close_trace();
+                status = ERROR_SUCCESS;
+                trace_.registrationHandle_ = INVALID_PROCESSTRACE_HANDLE;
+            }
         }
 
         error_check_common_conditions(status);

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -306,6 +306,9 @@ namespace krabs { namespace details {
                 trace_.registrationHandle_ = INVALID_PROCESSTRACE_HANDLE;
             }
             catch (invalid_parameter) {
+                // In some versions, the error code is 87 when using
+                // SystemTraceControlGuid session. If open/close doesn't
+                // throw, then we can continually processing events.
                 (void)open_trace();
                 close_trace();
                 status = ERROR_SUCCESS;

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.18</version>
+        <version>4.1.19</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>


### PR DESCRIPTION
As [issue #157](https://github.com/microsoft/krabsetw/issues/157) said, there is an error when manage the provider on Microsoft-Windows-Security-Auditing, tested on Windows10 1709, Windows server 2012 R2.

So I handle error code invalid_parameter (87) just the same as the catch for need_to_be_admin_failure (5).