### PR TITLE
Include record context when handling schema and unexpected errors

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Errors.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Errors.hpp
@@ -23,7 +23,18 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     /// <summary>
     /// Thrown when the schema for an event could not be found.
     /// </summary>
-    public ref struct CouldNotFindSchema : public System::Exception {};
+    public ref struct CouldNotFindSchema : public System::Exception {
+        /// <param name="msg">Additional context related to the error</param>
+        CouldNotFindSchema(System::String^ msg) : System::Exception(msg) { }
+    };
+
+    /// <summary>
+    /// Thrown when an error occurs that we did not explicitly handle.
+    /// </summary>
+    public ref struct UnexpectedError : public System::Exception {
+        /// <param name="msg">Additional context related to the error</param>
+        UnexpectedError(System::String^ msg) : System::Exception(msg) { }
+    };
 
     /// <summary>
     /// Thrown when an error is encountered parsing an ETW property.
@@ -76,6 +87,18 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         catch (const krabs::need_to_be_admin_failure &) \
         { \
             throw gcnew UnauthorizedAccessException("Need to be admin"); \
+        } \
+        catch (const krabs::function_not_supported &) \
+        { \
+            throw gcnew NotSupportedException(); \
+        } \
+        catch (const krabs::could_not_find_schema &ex) \
+        { \
+            throw gcnew CouldNotFindSchema(gcnew String(ex.what())); \
+        } \
+        catch (const krabs::unexpected_error &ex) \
+        { \
+            throw gcnew UnexpectedError(gcnew String(ex.what())); \
         } \
 
 } } } }

--- a/Microsoft.O365.Security.Native.ETW/Testing/RecordBuilder.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Testing/RecordBuilder.hpp
@@ -97,9 +97,10 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW { name
             SynthRecord^ managed = gcnew SynthRecord(nativeRecord);
             return managed;
         }
-        catch (const krabs::could_not_find_schema&)
+        catch (const krabs::could_not_find_schema& ex)
         {
-            throw gcnew CouldNotFindSchema();
+            auto msg = gcnew String(ex.what());
+            throw gcnew CouldNotFindSchema(msg);
         }
         catch (const std::invalid_argument& ex)
         {
@@ -122,9 +123,10 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW { name
             SynthRecord^ managed = gcnew SynthRecord(nativeRecord);
             return managed;
         }
-        catch (const krabs::could_not_find_schema&)
+        catch (const krabs::could_not_find_schema& ex)
         {
-            throw gcnew CouldNotFindSchema();
+            auto msg = gcnew String(ex.what());
+            throw gcnew CouldNotFindSchema(msg);
         }
         catch (const std::invalid_argument& ex)
         {

--- a/krabs/krabs/errors.hpp
+++ b/krabs/krabs/errors.hpp
@@ -42,6 +42,10 @@ namespace krabs {
         could_not_find_schema()
         : std::runtime_error("Could not find the schema")
         {}
+
+        could_not_find_schema(const std::string& context)
+            : std::runtime_error(std::string("An unexpected error occurred: ") + context)
+        {}
     };
 
     class type_mismatch_assert : public std::runtime_error {
@@ -61,6 +65,38 @@ namespace krabs {
             : std::runtime_error("No more trace sessions available.")
         {}
     };
+
+    class function_not_supported : public std::runtime_error {
+    public:
+        function_not_supported()
+            : std::runtime_error("This function is not supported on this system.")
+        {}
+    };
+
+    class unexpected_error : public std::runtime_error {
+    public:
+        unexpected_error(ULONG status)
+            : std::runtime_error(std::string("An unexpected error occurred: status=") +
+                std::to_string(status))
+        {}
+
+        unexpected_error(const std::string &context)
+            : std::runtime_error(std::string("An unexpected error occurred: ") + context)
+        {}
+    };
+
+    inline std::string get_status_and_record_context(ULONG status, const EVENT_RECORD& record)
+    {
+        std::stringstream message;
+        message << "status_code="
+            << status
+            << " provider_id="
+            << std::to_string(record.EventHeader.ProviderId)
+            << " event_id="
+            << record.EventHeader.EventDescriptor.Id;
+
+        return message.str();
+    }
 
     /**
      * <summary>Checks for common ETW API error codes.</summary>
@@ -83,9 +119,38 @@ namespace krabs {
             case ERROR_NO_SYSTEM_RESOURCES:
                 throw krabs::no_trace_sessions_remaining();
             case ERROR_NOT_SUPPORTED:
-                throw std::runtime_error("This function is not supported on this system");
+                throw krabs::function_not_supported();
             default:
-                throw std::runtime_error("Unexpected error");
+                throw krabs::unexpected_error(status);
+        }
+    }
+
+    /**
+     * <summary>Checks for common ETW API error codes and includes properties from the event record.</summary>
+     */
+    inline void error_check_common_conditions(ULONG status, const EVENT_RECORD &record)
+    {
+        if (status == ERROR_SUCCESS) {
+            return;
+        }
+
+        auto context = get_status_and_record_context(status, record);
+
+        switch (status) {
+        case ERROR_ALREADY_EXISTS:
+            throw krabs::trace_already_registered();
+        case ERROR_INVALID_PARAMETER:
+            throw krabs::invalid_parameter();
+        case ERROR_ACCESS_DENIED:
+            throw krabs::need_to_be_admin_failure();
+        case ERROR_NOT_FOUND:
+            throw krabs::could_not_find_schema(context);
+        case ERROR_NO_SYSTEM_RESOURCES:
+            throw krabs::no_trace_sessions_remaining();
+        case ERROR_NOT_SUPPORTED:
+            throw krabs::function_not_supported();
+        default:
+            throw krabs::unexpected_error(context);
         }
     }
 }

--- a/krabs/krabs/guid.hpp
+++ b/krabs/krabs/guid.hpp
@@ -300,6 +300,9 @@ namespace krabs {
 
 namespace std
 {
+    /*
+    * Converts a krabs GUID to a wide string
+    */
     inline std::wstring to_wstring(const krabs::guid& guid)
     {
         wchar_t* guidString;
@@ -310,6 +313,22 @@ namespace std
         std::unique_ptr<wchar_t, krabs::CoTaskMemDeleter> managed(guidString);
 
         return { managed.get() };
+    }
+
+    /*
+    * Converts a Windows GUID to a C string
+    */
+    inline std::string to_string(const GUID& guid)
+    {
+        char guid_string[37]; // 32 hex chars + 4 hyphens + null terminator
+        snprintf(
+            guid_string, sizeof(guid_string),
+            "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+            guid.Data1, guid.Data2, guid.Data3,
+            guid.Data4[0], guid.Data4[1], guid.Data4[2],
+            guid.Data4[3], guid.Data4[4], guid.Data4[5],
+            guid.Data4[6], guid.Data4[7]);
+        return guid_string;
     }
 
     template<>

--- a/krabs/krabs/schema_locator.hpp
+++ b/krabs/krabs/schema_locator.hpp
@@ -143,7 +143,7 @@ namespace krabs {
             &bufferSize);
 
         if (status != ERROR_INSUFFICIENT_BUFFER) {
-            error_check_common_conditions(status);
+            error_check_common_conditions(status, record);
         }
 
         // allocate and fill the schema from TDH
@@ -155,7 +155,8 @@ namespace krabs {
             0,
             NULL,
             (PTRACE_EVENT_INFO)buffer.get(),
-            &bufferSize));
+            &bufferSize),
+            record);
 
         return buffer;
     }


### PR DESCRIPTION
- Add CLI exception types for `schema not found` and `unexpected status code`
- Include status code, provider ID, and event record ID in the exception message when possible

![MicrosoftTeams-image (6)](https://user-images.githubusercontent.com/830389/131873641-7bcd524e-c96f-4538-8ebc-b23662b49c78.png)
