### PR TITLE
Add optional trace::create() method

### DIFF
--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -43,6 +43,13 @@ namespace krabs { namespace details {
 
         /**
          * <summary>
+         * Registers the ETW trace identified by the info in the trace type.
+         * </summary>
+         */
+        TRACEHANDLE register_trace();
+
+        /**
+         * <summary>
          * Starts the ETW trace identified by the info in the trace type.
          * </summary>
          */
@@ -95,7 +102,6 @@ namespace krabs { namespace details {
         trace_info fill_trace_info();
         EVENT_TRACE_LOGFILE fill_logfile();
         void close_trace();
-        void register_trace();
         EVENT_TRACE_PROPERTIES query_trace();
         void stop_trace();
         EVENT_TRACE_LOGFILE open_trace();
@@ -168,7 +174,9 @@ namespace krabs { namespace details {
     template <typename T>
     EVENT_TRACE_LOGFILE trace_manager<T>::open()
     {
-        register_trace();
+        if (trace_.registrationHandle_ == INVALID_PROCESSTRACE_HANDLE) {
+            (void)register_trace();
+        }
         enable_providers();
         return open_trace();
     }
@@ -280,7 +288,7 @@ namespace krabs { namespace details {
     }
 
     template <typename T>
-    void trace_manager<T>::register_trace()
+    TRACEHANDLE trace_manager<T>::register_trace()
     {
         trace_info info = fill_trace_info();
 
@@ -317,6 +325,7 @@ namespace krabs { namespace details {
         }
 
         error_check_common_conditions(status);
+        return trace_.registrationHandle_;
     }
 
     template <typename T>

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -96,7 +96,7 @@ namespace krabs {
         /**
          * <summary>
          * Sets the trace properties for a session.
-         * Must be called before open()/start().
+         * Must be called before create()/open()/start().
          * See https://docs.microsoft.com/en-us/windows/win32/etw/event-trace-properties
          * for important details and restrictions.
          * Configurable properties are ->
@@ -135,6 +135,25 @@ namespace krabs {
          * </example>
          */
         void enable(const typename T::provider_type &p);
+
+        /**
+         * <summary>
+         * Creates a trace session and returns a TRACEHANDLE.
+         * This method is optional. If not called, the trace session will be created automatically
+         * when calling start(). The method gives access to the TRACEHANDLE before the blocking
+         * call to start(), giving an opportunity to use TraceSetInformation whith the returned handle.
+         * </summary>
+         * <example>
+         *    krabs::trace trace;
+         *    krabs::guid id(L"{A0C1853B-5C40-4B15-8766-3CF1C58F985A}");
+         *    provider<> powershell(id);
+         *    trace.enable(powershell);
+         *    TRACEHANDLE trace_handle = trace.create();
+         *    TraceSetInformation(trace_handle, ...);
+         *    trace.start();
+         * </example>
+         */
+        TRACEHANDLE create();
 
         /**
          * <summary>
@@ -330,6 +349,12 @@ namespace krabs {
     void trace<T>::enable(const typename T::provider_type &p)
     {
         providers_.push_back(std::ref(p));
+    }
+
+    template <typename T>
+    TRACEHANDLE trace<T>::create() {
+        details::trace_manager<trace> manager(*this);
+        return manager.register_trace();
     }
 
     template <typename T>


### PR DESCRIPTION
Some providers are configured through the use of "TraceSetInformation"
which takes in a session handle. The session handle is available after
the call to "StartTrace" in "register_trace()". Add a "create()" method that
calls "register_trace" independently from "start()" to give an
opportunity to use "TraceSetInformation" with the returned handle
before the blocking call to "start()". Note that "create()" is optional.
If not called, the trace session will be created automatically when
calling "start()", as before.

Note that we could have used "ControlTrace" to obtain the handle of an
existing trace. However, since the session handle was assigned through
the "start()" method, which runs in its own thread, there is a race
condition.

Tests: all tests pass.