### PR TITLE
Gracefully handle schema errors when applying filters

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters." This is the Debug build.</summary>
-        <releaseNotes>Add additional context when handling errors</releaseNotes>
+        <releaseNotes>Gracefully handle schema errors when applying filters</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library. Also known as "Lobsters."</summary>
-        <releaseNotes>Add additional context when handling errors</releaseNotes>
+        <releaseNotes>Gracefully handle schema errors when applying filters</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs lobsters managed cppcli</tags>

--- a/krabs/krabs/errors.hpp
+++ b/krabs/krabs/errors.hpp
@@ -44,7 +44,7 @@ namespace krabs {
         {}
 
         could_not_find_schema(const std::string& context)
-            : std::runtime_error(std::string("An unexpected error occurred: ") + context)
+            : std::runtime_error(std::string("Could not find the schema: ") + context)
         {}
     };
 
@@ -76,7 +76,7 @@ namespace krabs {
     class unexpected_error : public std::runtime_error {
     public:
         unexpected_error(ULONG status)
-            : std::runtime_error(std::string("An unexpected error occurred: status=") +
+            : std::runtime_error(std::string("An unexpected error occurred: status_code=") +
                 std::to_string(status))
         {}
 

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Add additional context when handling errors</releaseNotes>
+        <releaseNotes>Gracefully handle schema errors when applying filters</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>


### PR DESCRIPTION
A schema lookup occurs when a predicate filter is applied to a record. If the schema lookup fails, a `krabs::could_not_find_schema` exception is thrown. This exception was previously unhandled and caused an exception to propagate on the main trace thread.

A better way to handle this is by catching the schema exception and notifying the application via an `OnError` delegate. This existed on the `Provider` flow but not on `EventFilter`.

This change adds an `OnError` delegate to the C++/CLI `EventFilter` class, wires it up to a callback in `event_filter`, and adds an appropriate `try`/`catch` in `event_filter::on_event` to use the new callback.