### PR TITLE
Add trace::set_trace_information method

### DIFF
--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -179,9 +179,7 @@ namespace krabs { namespace details {
     template <typename T>
     EVENT_TRACE_LOGFILE trace_manager<T>::open()
     {
-        if (trace_.registrationHandle_ == INVALID_PROCESSTRACE_HANDLE) {
-            (void)register_trace();
-        }
+        register_trace();
         enable_providers();
         return open_trace();
     }
@@ -204,10 +202,6 @@ namespace krabs { namespace details {
         PVOID trace_information,
         ULONG information_length)
     {
-        if (trace_.registrationHandle_ == INVALID_PROCESSTRACE_HANDLE) {
-            (void)register_trace();
-        }
-
         ULONG status = TraceSetInformation(
             trace_.registrationHandle_, 
             information_class,

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -80,12 +80,13 @@ namespace krabs { namespace details {
         /**
          * <summary>
          * Configures the ETW trace session settings.
+         * See https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-tracesetinformation.
          * </summary>
          */
         void set_trace_information(
-            TRACE_INFO_CLASS informationClass,
-            PVOID traceInformation,
-            ULONG informationLength);
+            TRACE_INFO_CLASS information_class,
+            PVOID trace_information,
+            ULONG information_length);
 
         /**
          * <summary>
@@ -199,9 +200,9 @@ namespace krabs { namespace details {
 
     template <typename T>
     void trace_manager<T>::set_trace_information(
-        TRACE_INFO_CLASS informationClass,
-        PVOID traceInformation,
-        ULONG informationLength)
+        TRACE_INFO_CLASS information_class,
+        PVOID trace_information,
+        ULONG information_length)
     {
         if (trace_.registrationHandle_ == INVALID_PROCESSTRACE_HANDLE) {
             (void)register_trace();
@@ -209,9 +210,9 @@ namespace krabs { namespace details {
 
         ULONG status = TraceSetInformation(
             trace_.registrationHandle_, 
-            informationClass, 
-            traceInformation, 
-            informationLength);
+            information_class,
+            trace_information,
+            information_length);
 
         error_check_common_conditions(status);
     }

--- a/krabs/krabs/etw.hpp
+++ b/krabs/krabs/etw.hpp
@@ -79,6 +79,16 @@ namespace krabs { namespace details {
 
         /**
          * <summary>
+         * Configures the ETW trace session settings.
+         * </summary>
+         */
+        void set_trace_information(
+            TRACE_INFO_CLASS informationClass,
+            PVOID traceInformation,
+            ULONG informationLength);
+
+        /**
+         * <summary>
          * Notifies the underlying trace of the buffers that were processed.
          * </summary>
          */
@@ -168,7 +178,9 @@ namespace krabs { namespace details {
     template <typename T>
     EVENT_TRACE_LOGFILE trace_manager<T>::open()
     {
-        register_trace();
+        if (trace_.registrationHandle_ == INVALID_PROCESSTRACE_HANDLE) {
+            (void)register_trace();
+        }
         enable_providers();
         return open_trace();
     }
@@ -183,6 +195,25 @@ namespace krabs { namespace details {
     EVENT_TRACE_PROPERTIES trace_manager<T>::query()
     {
         return query_trace();
+    }
+
+    template <typename T>
+    void trace_manager<T>::set_trace_information(
+        TRACE_INFO_CLASS informationClass,
+        PVOID traceInformation,
+        ULONG informationLength)
+    {
+        if (trace_.registrationHandle_ == INVALID_PROCESSTRACE_HANDLE) {
+            (void)register_trace();
+        }
+
+        ULONG status = TraceSetInformation(
+            trace_.registrationHandle_, 
+            informationClass, 
+            traceInformation, 
+            informationLength);
+
+        error_check_common_conditions(status);
     }
 
     template <typename T>

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -125,6 +125,30 @@ namespace krabs {
 
         /**
          * <summary>
+         * Configures trace session settings.
+         * See https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-tracesetinformation
+         * for more information.
+         * </summary>
+         * <example>
+         *    krabs::trace trace;
+         *    // Adjust SE_SYSTEM_PROFILE_NAME token privilege through AdjustTokenPrivileges(...)
+         *    // to enable stack tracing (not done in this example). Then:
+         *    STACK_TRACING_EVENT_ID event_id = {0};
+         *    event_id.EventGuid = krabs::guids::perf_info;
+         *    event_id.Type = 46; // SampleProfile
+         *    trace_.set_trace_information(TraceStackTracingInfo, &event_id, sizeof(STACK_TRACING_EVENT_ID));
+         *    krabs::kernel_provider stack_walk_provider(EVENT_TRACE_FLAG_PROFILE, krabs::guids::stack_walk);
+         *    trace_.enable(stack_walk_provider);
+         *    trace.start();
+         * </example>
+         */
+        void set_trace_information(
+            TRACE_INFO_CLASS informationClass,
+            PVOID traceInformation,
+            ULONG informationLength);
+
+        /**
+         * <summary>
          * Enables the provider on the given user trace.
          * </summary>
          * <example>
@@ -317,6 +341,16 @@ namespace krabs {
         properties_.MaximumBuffers = properties->MaximumBuffers;
         properties_.FlushTimer = properties->FlushTimer;
         properties_.LogFileMode = properties->LogFileMode;
+    }
+
+    template <typename T>
+    void trace<T>::set_trace_information(
+        TRACE_INFO_CLASS informationClass,
+        PVOID traceInformation,
+        ULONG informationLength)
+    {
+        details::trace_manager<trace> manager(*this);
+        manager.set_trace_information(informationClass, traceInformation, informationLength);
     }
 
     template <typename T>

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -143,9 +143,9 @@ namespace krabs {
          * </example>
          */
         void set_trace_information(
-            TRACE_INFO_CLASS informationClass,
-            PVOID traceInformation,
-            ULONG informationLength);
+            TRACE_INFO_CLASS information_class,
+            PVOID trace_information,
+            ULONG information_length);
 
         /**
          * <summary>
@@ -345,12 +345,12 @@ namespace krabs {
 
     template <typename T>
     void trace<T>::set_trace_information(
-        TRACE_INFO_CLASS informationClass,
-        PVOID traceInformation,
-        ULONG informationLength)
+        TRACE_INFO_CLASS information_class,
+        PVOID trace_information,
+        ULONG information_length)
     {
         details::trace_manager<trace> manager(*this);
-        manager.set_trace_information(informationClass, traceInformation, informationLength);
+        manager.set_trace_information(information_class, trace_information, information_length);
     }
 
     template <typename T>

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -126,6 +126,7 @@ namespace krabs {
         /**
          * <summary>
          * Configures trace session settings.
+         * Must be called after open().
          * See https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-tracesetinformation
          * for more information.
          * </summary>
@@ -136,10 +137,11 @@ namespace krabs {
          *    STACK_TRACING_EVENT_ID event_id = {0};
          *    event_id.EventGuid = krabs::guids::perf_info;
          *    event_id.Type = 46; // SampleProfile
+         *    trace_.open();
          *    trace_.set_trace_information(TraceStackTracingInfo, &event_id, sizeof(STACK_TRACING_EVENT_ID));
          *    krabs::kernel_provider stack_walk_provider(EVENT_TRACE_FLAG_PROFILE, krabs::guids::stack_walk);
          *    trace_.enable(stack_walk_provider);
-         *    trace.start();
+         *    trace.process();
          * </example>
          */
         void set_trace_information(


### PR DESCRIPTION
Some providers need to be configured through ETW's TraceSetInformation
function which we wrap inside trace::set_trace_information to maintain
encapsulation of the trace handle.

Tests: Setup sampling profiling. All tests pass.

See discussion in #171 