### PR TITLE
Rename .targets file and add missing assert specialization for bool

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</summary>
-        <releaseNotes>Rename targets file to match nuget id. Add assert specialization for bool.</releaseNotes>
+        <releaseNotes>Rename targets file to match nuget id.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs managed cppcli</tags>

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</summary>
-        <releaseNotes>Rename targets file to match nuget id. Add assert specialization for bool.</releaseNotes>
+        <releaseNotes>Rename targets file to match nuget id.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs managed cppcli</tags>

--- a/krabs/krabs/tdh_helpers.hpp
+++ b/krabs/krabs/tdh_helpers.hpp
@@ -147,9 +147,6 @@ namespace krabs {
         BUILD_ASSERT(int64_t, TDH_INTYPE_INT64);
         BUILD_ASSERT(uint64_t, TDH_INTYPE_UINT64);
 
-        // boolean
-        BUILD_ASSERT(bool, TDH_INTYPE_BOOLEAN);
-
         // floating
         BUILD_ASSERT(float, TDH_INTYPE_FLOAT);
         BUILD_ASSERT(double, TDH_INTYPE_DOUBLE);

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -11,7 +11,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
-        <releaseNotes>Rename targets file to match nuget id. Add assert specialization for bool.</releaseNotes>
+        <releaseNotes>Rename targets file to match nuget id.</releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />
         <tags>ETW krabs krabsetw native headers cpp</tags>


### PR DESCRIPTION
Fix #184 by renaming .targets file to match nuget ID.

Fix #177 by adding `assert_valid_assignment` specialization that was missed in #148.