### PR TITLE
Add a method to return the provider GUID from a given schema

### DIFF
--- a/krabs/krabs/schema.hpp
+++ b/krabs/krabs/schema.hpp
@@ -166,6 +166,20 @@ namespace krabs {
 
         /**
          * <summary>
+         * Returns the provider GUID of an event via its schema.
+         * </summary>
+         * <example>
+         *    void on_event(const EVENT_RECORD &record, const krabs::trace_context &trace_context)
+         *    {
+         *        krabs::schema schema(record, trace_context.schema_locator);
+         *        GUID guid = krabs::provider_id(schema);
+         *    }
+         * </example>
+         */
+        GUID provider_id() const;
+
+        /**
+         * <summary>
          * Returns the provider name of an event via its schema.
          * </summary>
          * <example>
@@ -360,6 +374,11 @@ namespace krabs {
     inline unsigned int schema::event_flags() const
     {
         return record_.EventHeader.Flags;
+    }
+
+    inline GUID schema::provider_id() const
+    {
+        return record_.EventHeader.ProviderId;
     }
 
     inline const wchar_t *schema::provider_name() const


### PR DESCRIPTION
A schema has the provider GUID available but no way to access it. Having the provider GUID available from a schema enables applications to use the schema directly for GUID comparisons without relying on existing provide_name() string comparisons.