### PR TITLE
Add a trace interface to enable ignoring MOF events

### DIFF
--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -282,6 +282,20 @@ namespace krabs {
          */
         void set_default_event_callback(c_provider_callback callback);
 
+        /**
+         * <summary>
+         * Ignore Classic/MOF events that require calling TDH to get the provider which case be slow.
+         * Default behavior will leave MOF events enabled.
+         * </summary>
+         *
+         * <param name="ignore_mof_events">true to ignore MOF events</param>
+         * <example>
+         *    krabs::trace trace;
+         *    trace.set_ignore_mof_events(true);
+         * </example>
+         */
+        void set_ignore_mof_events(bool ignore_mof_events);
+
     private:
 
         /**
@@ -307,6 +321,8 @@ namespace krabs {
         const trace_context context_;
 
         provider_callback default_callback_ = nullptr;
+
+        bool ignore_mof_events_ = false;
 
     private:
         template <typename T>
@@ -443,4 +459,9 @@ namespace krabs {
         default_callback_ = callback;
     }
 
+    template <typename T>
+    void trace<T>::set_ignore_mof_events(bool ignore_mof_events)
+    {
+        ignore_mof_events_  = ignore_mof_events;
+    }
 }

--- a/krabs/krabs/ut.hpp
+++ b/krabs/krabs/ut.hpp
@@ -235,15 +235,18 @@ namespace krabs { namespace details {
             }
         }
 
-        // for MOF providers, EventHeader.Provider is the *Message* GUID
-        // we need to ask TDH for event information in order to determine the
-        // correct provider to pass this event to
-        auto schema = get_event_schema_from_tdh(record);
-        auto eventInfo = reinterpret_cast<PTRACE_EVENT_INFO>(schema.get());
-        for (auto& provider : trace.providers_) {
-            if (eventInfo->ProviderGuid == provider.get().guid_) {
-                provider.get().on_event(record, trace.context_);
-                return;
+        if (!trace.ignore_mof_events_)
+        {
+            // for MOF providers, EventHeader.Provider is the *Message* GUID
+            // we need to ask TDH for event information in order to determine the
+            // correct provider to pass this event to
+            auto schema = get_event_schema_from_tdh(record);
+            auto eventInfo = reinterpret_cast<PTRACE_EVENT_INFO>(schema.get());
+            for (auto& provider : trace.providers_) {
+                if (eventInfo->ProviderGuid == provider.get().guid_) {
+                    provider.get().on_event(record, trace.context_);
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
MOF events all require a (slow) TDH lookup which can fail if schema is not available.  Since these are generally legacy events, many applications may not require them and ignoring them can provide a significant performance increase, particularly for large trace files.