### PR TITLE
Correctly handle kernel addresses in an x86 stack trace

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/AssemblyInfo.cpp
+++ b/Microsoft.O365.Security.Native.ETW/AssemblyInfo.cpp
@@ -32,7 +32,7 @@ using namespace System::Security::Permissions;
 // You can specify all the value or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly:AssemblyVersionAttribute("4.4.0.0")];
+[assembly:AssemblyVersionAttribute("4.4.1.0")];
 
 [assembly:ComVisible(false)];
 

--- a/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
@@ -774,12 +774,12 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// Retrieves the call stack associated with the record, if enabled.
         /// </summary>
         /// <returns>a list of return addresses</returns>
-        virtual List<UIntPtr>^ GetStackTrace()
+        virtual List<UInt64>^ GetStackTrace()
         {
-            auto stackTrace = gcnew List<UIntPtr>();
+            auto stackTrace = gcnew List<UInt64>();
             for (auto& returnAddress : schema_->stack_trace())
             {
-                stackTrace->Add(UIntPtr(returnAddress));
+                stackTrace->Add(UInt64(returnAddress));
             }
             return stackTrace;
         }

--- a/Microsoft.O365.Security.Native.ETW/IEventRecord.hpp
+++ b/Microsoft.O365.Security.Native.ETW/IEventRecord.hpp
@@ -407,7 +407,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         ///  Retrieves the call stack associated with the record, if enabled.
         /// </summary>
         /// <returns>a list of return addresses</returns>
-        List<UIntPtr>^ GetStackTrace();
+        List<UInt64>^ GetStackTrace();
     };
 
 } } } }

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.4.0</version>
+        <version>4.4.1</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,8 @@
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</summary>
         <releaseNotes>
-            Version 4.4.0:
-              - Add support for Windows ARM64
+            Version 4.4.1:
+              - Correctly handle 8-byte long addresses in an x86 application
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.4.0</version>
+        <version>4.4.1</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,8 @@
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</summary>
         <releaseNotes>
-            Version 4.4.0:
-              - Add support for Windows ARM64
+            Version 4.4.1:
+              - Correctly handle 8-byte long addresses in an x86 application
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/examples/ManagedExamples/UserTrace007_StackTrace.cs
+++ b/examples/ManagedExamples/UserTrace007_StackTrace.cs
@@ -47,7 +47,6 @@ namespace ManagedExamples
                     return; // ignore failures
 
                 var callStack = record.GetStackTrace()
-                                .Select(a => a.ToUInt64())
                                 .Where(a => a < 0xFFFF000000000000) // skip kernel addresses (for now)
                                 .Select(a => MemoryMap.GetClosestSymbol(processId, a));
 

--- a/krabs/krabs/schema.hpp
+++ b/krabs/krabs/schema.hpp
@@ -256,11 +256,11 @@ namespace krabs {
         *    void on_event(const EVENT_RECORD &record, const krabs::trace_context &trace_context)
         *    {
         *        krabs::schema schema(record, trace_context.schema_locator);
-        *        std::vector<ULONG_PTR> stack_trace = schema.stack_trace();
+        *        std::vector<ULONG64> stack_trace = schema.stack_trace();
         *    }
         * </example>
         */
-        std::vector<ULONG_PTR> stack_trace() const;
+        std::vector<ULONG64> stack_trace() const;
 
     private:
         const EVENT_RECORD &record_;
@@ -277,8 +277,8 @@ namespace krabs {
         friend GUID activity_id(const schema&);
         friend int event_id(const EVENT_RECORD &);
         friend int event_id(const schema &);
-        friend std::vector<ULONG_PTR> stack_trace(const schema&);
-        friend std::vector<ULONG_PTR> stack_trace(const EVENT_RECORD&);
+        friend std::vector<ULONG64> stack_trace(const schema&);
+        friend std::vector<ULONG64> stack_trace(const EVENT_RECORD&);
 
         friend class parser;
         friend class property_iterator;
@@ -408,9 +408,9 @@ namespace krabs {
         return record_.EventHeader.ActivityId;
     }
 
-    inline std::vector<ULONG_PTR> schema::stack_trace() const
+    inline std::vector<ULONG64> schema::stack_trace() const
     {
-        std::vector<ULONG_PTR> call_stack;
+        std::vector<ULONG64> call_stack;
         if (record_.ExtendedDataCount != 0) {
             for (USHORT i = 0; i < record_.ExtendedDataCount; i++)
             {

--- a/krabs/krabs/testing/extended_data_builder.hpp
+++ b/krabs/krabs/testing/extended_data_builder.hpp
@@ -136,7 +136,7 @@ namespace krabs { namespace testing {
         auto array_ptr = reinterpret_cast<EVENT_HEADER_EXTENDED_DATA_ITEM*>(data_buffer);
         auto data_ptr = data_buffer + array_part_size;
 
-        for (int i = 0; i < items_.size(); i++)
+        for (size_t i = 0; i < items_.size(); i++)
         {
             // 2a: write the struct
             auto& destination = array_ptr[i];

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.4.0</version>
+        <version>4.4.1</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,8 @@
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
         <releaseNotes>
-            Version 4.4.0:
-              - Add support for Windows ARM64
+            Version 4.4.1:
+              - Correctly handle 8-byte long addresses in an x86 application
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />


### PR DESCRIPTION
On an x86 application, ULONG_PTR is 4 bytes long, which means it cannot handle 8-byte long kernel addresses used by a 64-bit system.