### PR TITLE
Only allocate one EventRecordMetadata^ and reuse it for RawProvider events

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/AssemblyInfo.cpp
+++ b/Microsoft.O365.Security.Native.ETW/AssemblyInfo.cpp
@@ -32,7 +32,7 @@ using namespace System::Security::Permissions;
 // You can specify all the value or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly:AssemblyVersionAttribute("4.4.2.0")];
+[assembly:AssemblyVersionAttribute("4.4.3.0")];
 
 [assembly:ComVisible(false)];
 

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -17,14 +17,15 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     /// </summary>
     public ref class EventRecordMetadata : public IEventRecordMetadata
     {
-    protected:
-        const EVENT_RECORD* record_;
-        const EVENT_HEADER* header_;
-
     internal:
         EventRecordMetadata(const EVENT_RECORD& record)
             : record_(&record)
             , header_(&record.EventHeader) { }
+
+        EventRecordMetadata() { }
+
+        const EVENT_RECORD* record_;
+        const EVENT_HEADER* header_;
 
     public:
         // For container ID's, we are expecting format "00000000-0000-0000-0000-0000000000000", 

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -17,6 +17,10 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     /// </summary>
     public ref class EventRecordMetadata : public IEventRecordMetadata
     {
+    protected:
+        const EVENT_RECORD* record_;
+        const EVENT_HEADER* header_;
+
     internal:
         EventRecordMetadata(const EVENT_RECORD& record)
             : record_(&record)
@@ -24,8 +28,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
         EventRecordMetadata() { }
 
-        const EVENT_RECORD* record_;
-        const EVENT_HEADER* header_;
+        virtual void Update(const EVENT_RECORD& record)
+        {
+            record_ = &record;
+            header_ = &record.EventHeader;
+        }
 
     public:
         // For container ID's, we are expecting format "00000000-0000-0000-0000-0000000000000", 

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -28,6 +28,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
         EventRecordMetadata() { }
 
+        /// <summary>
+        /// Update the underlying pointers to the event data to the given record.
+        /// </summary>
         virtual void Update(const EVENT_RECORD& record)
         {
             record_ = &record;

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -29,7 +29,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         EventRecordMetadata() { }
 
         /// <summary>
-        /// Update the underlying pointers to the event data to the given record.
+        /// Updates this instance to point to the specified event record.
         /// </summary>
         virtual void Update(const EVENT_RECORD& record)
         {

--- a/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
@@ -168,8 +168,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
     inline void RawProvider::EventNotification(const EVENT_RECORD &record)
     {
-        data_->record_ = &record;
-        data_->header_ = &record.EventHeader;
+        data_->Update(record);
 
         OnEvent(data_);
     }

--- a/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
@@ -122,6 +122,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         NativePtr<krabs::provider<>> provider_;
         GCHandle delegateHookHandle_;
         GCHandle delegateHandle_;
+        EventRecordMetadata^ data_;
         void SetUpProvider();
     };
 
@@ -148,6 +149,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         delegateHookHandle_ = GCHandle::Alloc(bridged);
 
         provider_->add_on_event_callback((krabs::c_provider_callback)bridged.ToPointer());
+
+        data_ = gcnew EventRecordMetadata();
     }
 
     inline RawProvider::~RawProvider()
@@ -165,6 +168,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
     inline void RawProvider::EventNotification(const EVENT_RECORD &record)
     {
-        OnEvent(gcnew EventRecordMetadata(record));
+        data_->record_ = &record;
+        data_->header_ = &record.EventHeader;
+
+        OnEvent(data_);
     }
 } } } }

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.4.2</version>
+        <version>4.4.3</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,8 @@
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</summary>
         <releaseNotes>
-            Version 4.4.2:
-              - Support reading TraceLogging events.
+            Version 4.4.3:
+              - RawProvider only allocates EventRecordMetadata once per instance.
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.4.2</version>
+        <version>4.4.3</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,8 @@
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</summary>
         <releaseNotes>
-            Version 4.4.2:
-              - Support reading TraceLogging events.
+            Version 4.4.3:
+              - RawProvider only allocates EventRecordMetadata once per instance.
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.4.2</version>
+        <version>4.4.3</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,8 @@
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
         <releaseNotes>
-            Version 4.4.2:
-              - Support reading TraceLogging events.
+            Version 4.4.3:
+              - RawProvider only allocates EventRecordMetadata once per instance.
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />


### PR DESCRIPTION
RawProvider::EventNotification created a new managed object EventRecordMetadata for each EVENT_RECORD it received. Since each provider is single threaded, we should be able to reuse a single allocation by replacing the pointers to the user data in EVENT_RECORD native object on a single EventRecordMetadata before raising the event up to the managed layer.

This change makes the user record and the header pointers in EventRecordMetadata accessible internally so that they can be updated from each EVENT_RECORD received in the RawProvider. RawProvider adds a EventRecordMetadata^ member that gets initialized in the constructor and re-used for each EVENT_RECORD by updating the two pointers each time.