### PR TITLE
Add functions to disable MOF/WPP events processing and function to get event type

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
@@ -75,6 +75,14 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
             String^ get() { return gcnew String(schema_->provider_name()); }
         }
 
+        /// <summary>
+        /// Returns the decoding source of the event.
+        /// </summary>
+        virtual property ETW::DecodingSource DecodingSource
+        {
+            ETW::DecodingSource get() { return (ETW::DecodingSource)schema_->decoding_source(); }
+        }
+
 #pragma endregion
 
 #pragma region Parser

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -142,6 +142,19 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
             Guid get() { return ConvertGuid(header_->ActivityId); }
         }
 
+        /// <summary>
+        /// Returns the type of the event record.
+        /// DecodingSourceXMLFile - The event was emitted by a manifest-based provider.
+        /// DecodingSourceWbem - The event was emitted by a MOF-based provider.
+        /// DecodingSourceWPP - The event was emitted by a WPP software tracing provider.
+        /// DecodingSourceTlg - The event was emitted by a TraceLogging provider.
+        /// </summary>
+        /// <returns>the type of the event record</returns>
+        virtual DecodingSource GetEventType()
+        {
+            return (DecodingSource)krabs::get_event_type(*record_);
+        }
+
 #pragma endregion
 
 #pragma region EventRecord

--- a/Microsoft.O365.Security.Native.ETW/IEventRecord.hpp
+++ b/Microsoft.O365.Security.Native.ETW/IEventRecord.hpp
@@ -41,6 +41,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// </summary>
         property String^ ProviderName { String^ get(); }
 
+        /// <summary>
+        /// Returns the decoding source of the event.
+        /// </summary>
+        property ETW::DecodingSource DecodingSource { ETW::DecodingSource get(); }
+
         // Parser Methods
 
         /// <summary>

--- a/Microsoft.O365.Security.Native.ETW/IEventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/IEventRecordMetadata.hpp
@@ -8,7 +8,6 @@ using namespace System::Runtime::InteropServices;
 
 namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
-
     /// <summary>
     /// From the EVENT_HEADER.EventProperty defines:
     /// https://msdn.microsoft.com/en-us/library/windows/desktop/aa363759(v=vs.85).aspx
@@ -18,6 +17,19 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         XML             = 0x0001,
         FORWARDED_XML   = 0x0002,
         LEGACY_EVENTLOG = 0x0004
+    };
+
+    /// <summary>
+    /// From the TRACE_EVENT_INFO.DecodingSource defines:
+    /// https://learn.microsoft.com/en-us/windows/win32/api/tdh/ne-tdh-decoding_source
+    /// </summary>
+    public enum class DecodingSource
+    {
+        XMLFile,
+        Wbem,
+        WPP,
+        Tlg,
+        Max
     };
 
     /// <summary>
@@ -87,6 +99,16 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// Returns the Activity ID associated with this event.
         /// </summary>
         property Guid ActivityId { Guid get(); }
+
+        /// <summary>
+        /// Returns the type of the event record.
+        /// DecodingSourceXMLFile - The event was emitted by a manifest-based provider.
+        /// DecodingSourceWbem - The event was emitted by a MOF-based provider.
+        /// DecodingSourceWPP - The event was emitted by a WPP software tracing provider.
+        /// DecodingSourceTlg - The event was emitted by a TraceLogging provider.
+        /// </summary>
+        /// <returns>the type of the event record</returns>
+        DecodingSource GetEventType();
 
 #pragma endregion
 

--- a/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
@@ -143,6 +143,21 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         virtual TraceStats QueryStats();
 
         /// <summary>
+        /// Get the number of buffers processed by this trace
+        /// </summary>
+        /// <example>
+        ///     KernelTrace trace = new KernelTrace();
+        ///     // ...
+        ///     trace.Start();
+        ///     trace.Stop();
+        ///     Console.WriteLine("Buffers processed: " + trace.BuffersProcessed);
+        /// </example>
+        virtual property uint64_t BuffersProcessed
+        {
+            uint64_t get();
+        }
+
+        /// <summary>
         /// Adds a function to call when an event is fired which has no corresponding provider.
         /// </summary>
         /// <param name="callback">the function to call into</param>
@@ -211,7 +226,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         _properties.MaximumBuffers = properties->MaximumBuffers;
         _properties.LogFileMode = properties->LogFileMode;
         _properties.FlushTimer = properties->FlushTimer;
-        ExecuteAndConvertExceptions(return trace_->set_trace_properties(&_properties));
+        trace_->set_trace_properties(&_properties);
     }
 
     inline void KernelTrace::Open()
@@ -232,6 +247,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline TraceStats KernelTrace::QueryStats()
     {
         ExecuteAndConvertExceptions(return TraceStats(trace_->query_stats()));
+    }
+
+    inline uint64_t KernelTrace::BuffersProcessed::get()
+    {
+        return trace_->buffers_processed();
     }
 
     inline void KernelTrace::SetDefaultEventCallback(IEventRecordDelegate^ callback)

--- a/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
@@ -166,7 +166,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
 
         /// <summary>
-        /// Gets or sets whether to enable getting schema information for MOF events.
+        /// Sets whether to enable getting schema information for MOF events.
         /// </summary>
         /// <example>
         ///     UserTrace trace = new UserTrace();
@@ -178,7 +178,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         }
 
         /// <summary>
-        /// Gets or sets whether to enable getting schema information for WPP events.
+        /// Sets whether to enable getting schema information for WPP events.
         /// </summary>
         /// <example>
         ///     UserTrace trace = new UserTrace();

--- a/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
@@ -150,6 +150,45 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// <returns>the <see cref="O365::Security::ETW::TraceStats"/> for the current trace object</returns>
         virtual TraceStats QueryStats();
 
+        /// <summary>
+        /// Get the number of buffers processed by this trace
+        /// </summary>
+        /// <example>
+        ///     UserTrace trace = new UserTrace();
+        ///     // ...
+        ///     trace.Start();
+        ///     trace.Stop();
+        ///     Console.WriteLine("Buffers processed: " + trace.BuffersProcessed);
+        /// </example>
+        virtual property uint64_t BuffersProcessed
+        {
+            uint64_t get();
+        }
+
+        /// <summary>
+        /// Gets or sets whether to enable getting schema information for MOF events.
+        /// </summary>
+        /// <example>
+        ///     UserTrace trace = new UserTrace();
+        ///     trace.MOFEventProcessingEnabled = false;
+        /// </example>
+        virtual property bool MOFEventProcessingEnabled
+        {
+            void set(bool value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether to enable getting schema information for WPP events.
+        /// </summary>
+        /// <example>
+        ///     UserTrace trace = new UserTrace();
+        ///     trace.WPPEventProcessingEnabled = false;
+        /// </example>
+        virtual property bool WPPEventProcessingEnabled
+        {
+            void set(bool value);
+        }
+
     internal:
         bool disposed_ = false;
         O365::Security::ETW::NativePtr<krabs::user_trace> trace_;
@@ -198,7 +237,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         _properties.MaximumBuffers = properties->MaximumBuffers;
         _properties.LogFileMode = properties->LogFileMode;
         _properties.FlushTimer = properties->FlushTimer;
-        ExecuteAndConvertExceptions(return trace_->set_trace_properties(&_properties));
+        trace_->set_trace_properties(&_properties);
     }
 
     inline void UserTrace::Open()
@@ -219,6 +258,21 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline TraceStats UserTrace::QueryStats()
     {
         ExecuteAndConvertExceptions(return TraceStats(trace_->query_stats()));
+    }
+
+    inline uint64_t UserTrace::BuffersProcessed::get()
+    {
+        return trace_->buffers_processed();
+    }
+
+    inline void UserTrace::MOFEventProcessingEnabled::set(bool value)
+    {
+        trace_->set_mof_event_processing_enabled(value);
+    }
+
+    inline void UserTrace::WPPEventProcessingEnabled::set(bool value)
+    {
+        trace_->set_wpp_event_processing_enabled(value);
     }
 
 } } } }

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -284,17 +284,17 @@ namespace krabs {
 
         /**
          * <summary>
-         * Ignore Classic/MOF events that require calling TDH to get the provider which case be slow.
-         * Default behavior will leave MOF events enabled.
+         * Sets whether to enable getting schema information for MOF events.
+         * Default behavior is to get schema information for MOF events.
          * </summary>
          *
-         * <param name="ignore_mof_events">true to ignore MOF events</param>
+         * <param name="mof_events_enabled">false to disable MOF events</param>
          * <example>
          *    krabs::trace trace;
-         *    trace.set_ignore_mof_events(true);
+         *    trace.set_mof_event_processing_enabled(false);
          * </example>
          */
-        void set_ignore_mof_events(bool ignore_mof_events);
+        void set_mof_event_processing_enabled(bool mof_events_enabled);
 
     private:
 
@@ -322,7 +322,7 @@ namespace krabs {
 
         provider_callback default_callback_ = nullptr;
 
-        bool ignore_mof_events_ = false;
+        bool mof_events_enabled_ = true;
 
     private:
         template <typename T>
@@ -460,8 +460,8 @@ namespace krabs {
     }
 
     template <typename T>
-    void trace<T>::set_ignore_mof_events(bool ignore_mof_events)
+    void trace<T>::set_mof_event_processing_enabled(bool mof_events_enabled)
     {
-        ignore_mof_events_  = ignore_mof_events;
+        mof_events_enabled_ = mof_events_enabled;
     }
 }

--- a/krabs/krabs/trace.hpp
+++ b/krabs/krabs/trace.hpp
@@ -282,6 +282,20 @@ namespace krabs {
          */
         void set_default_event_callback(c_provider_callback callback);
 
+        /**
+         * <summary>
+         * Ignore Classic/MOF events that require calling TDH to get the provider which case be slow.
+         * Default behavior will leave MOF events enabled.
+         * </summary>
+         *
+         * <param name="ignore_mof_events">true to ignore MOF events</param>
+         * <example>
+         *    krabs::trace trace;
+         *    trace.set_ignore_mof_events(true);
+         * </example>
+         */
+        void set_ignore_mof_events(bool ignore_mof_events);
+
     private:
 
         /**
@@ -307,6 +321,8 @@ namespace krabs {
         const trace_context context_;
 
         provider_callback default_callback_ = nullptr;
+
+        bool ignore_mof_events_ = false;
 
     private:
         template <typename T>
@@ -443,4 +459,9 @@ namespace krabs {
         default_callback_ = callback;
     }
 
+    template <typename T>
+    void trace<T>::set_ignore_mof_events(bool ignore_mof_events)
+    {
+        ignore_mof_events_  = ignore_mof_events;
+    }
 }

--- a/krabs/krabs/ut.hpp
+++ b/krabs/krabs/ut.hpp
@@ -227,16 +227,19 @@ namespace krabs { namespace details {
         const EVENT_RECORD &record,
         const krabs::trace<krabs::details::ut> &trace)
     {
-        // for manifest providers, EventHeader.ProviderId is the Provider GUID
-        for (auto& provider : trace.providers_) {
-            if (record.EventHeader.ProviderId == provider.get().guid_) {
-                provider.get().on_event(record, trace.context_);
-                return;
+        auto type = get_event_type(record);
+
+        if (type == DecodingSourceXMLFile || type == DecodingSourceTlg) {
+            // for manifest/TraceLogging providers, EventHeader.ProviderId is the Provider GUID
+            for (auto& provider : trace.providers_) {
+                if (record.EventHeader.ProviderId == provider.get().guid_) {
+                    provider.get().on_event(record, trace.context_);
+                    return;
+                }
             }
         }
-
-        if (trace.mof_events_enabled_) {
-            // for MOF providers, EventHeader.Provider is the *Message* GUID
+        else if (((type == DecodingSourceWbem) && trace.mof_events_enabled_) || ((type == DecodingSourceWPP) && trace.wpp_events_enabled_)) {
+            // for MOF/WPP providers, EventHeader.Provider is the *Message* GUID
             // we need to ask TDH for event information in order to determine the
             // correct provider to pass this event to
             auto schema = get_event_schema_from_tdh(record);

--- a/krabs/krabs/ut.hpp
+++ b/krabs/krabs/ut.hpp
@@ -235,15 +235,18 @@ namespace krabs { namespace details {
             }
         }
 
-        // for MOF providers, EventHeader.Provider is the *Message* GUID
-        // we need to ask TDH for event information in order to determine the
-        // correct provider to pass this event to
-        auto schema = get_event_schema_from_tdh(record);
-        auto eventInfo = reinterpret_cast<PTRACE_EVENT_INFO>(schema.get());
-        for (auto& provider : trace.providers_) {
-            if (eventInfo->ProviderGuid == provider.get().guid_) {
-                provider.get().on_event(record, trace.context_);
-                return;
+        if (!trace.ignore_mof_events_)
+        {
+            // for MOF providers, EventHeader.Provider is the *Message* GUID
+            // we need to ask TDH for event information in order to determine the
+            // correct provider to pass this event to
+            auto schema = get_event_schema_from_tdh(record);
+            auto eventInfo = reinterpret_cast<PTRACE_EVENT_INFO>(schema.get());
+            for (auto& provider : trace.providers_) {
+                if (eventInfo->ProviderGuid == provider.get().guid_) {
+                    provider.get().on_event(record, trace.context_);
+                    return;
+                }
             }
         }
 

--- a/krabs/krabs/ut.hpp
+++ b/krabs/krabs/ut.hpp
@@ -235,8 +235,7 @@ namespace krabs { namespace details {
             }
         }
 
-        if (!trace.ignore_mof_events_)
-        {
+        if (trace.mof_events_enabled_) {
             // for MOF providers, EventHeader.Provider is the *Message* GUID
             // we need to ask TDH for event information in order to determine the
             // correct provider to pass this event to

--- a/krabs/krabs/ut.hpp
+++ b/krabs/krabs/ut.hpp
@@ -238,7 +238,8 @@ namespace krabs { namespace details {
                 }
             }
         }
-        else if (((type == DecodingSourceWbem) && trace.mof_events_enabled_) || ((type == DecodingSourceWPP) && trace.wpp_events_enabled_)) {
+        else if ((type == DecodingSourceWbem && trace.mof_events_enabled_) ||
+            (type == DecodingSourceWPP && trace.wpp_events_enabled_)) {
             // for MOF/WPP providers, EventHeader.Provider is the *Message* GUID
             // we need to ask TDH for event information in order to determine the
             // correct provider to pass this event to


### PR DESCRIPTION
Based on https://github.com/microsoft/krabsetw/pull/210

- Add functions to disable MOF/WPP events processing
- Add function to get event type - the logic is reverse-engineered from tdh!TdhGetEventInformation
- Add the corresponding .NET wrapper and supplement what was missing before.


