### PR TITLE
Unify. NET wrappers of callbacks and more optimizations

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Callbacks.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Callbacks.hpp
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <krabs.hpp>
+
+#include "EventRecord.hpp"
+#include "EventRecordError.hpp"
+
+using namespace System;
+using namespace System::Runtime::InteropServices;
+
+namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
+
+    /// <summary>
+    /// Delegate called when a new ETW <see cref="O365::Security::ETW::EventRecord"/> is received.
+    /// </summary>
+    public delegate void IEventRecordDelegate(IEventRecord^ record);
+
+    /// <summary>
+    /// Delegate called when a new ETW <see cref="O365::Security::ETW::EventRecordMetadata"/> is received.
+    /// </summary>
+    public delegate void IEventRecordMetadataDelegate(IEventRecordMetadata^ record);
+
+    /// <summary>
+    /// Delegate called on errors when processing an <see cref="O365::Security::ETW::EventRecord"/>.
+    /// </summary>
+    public delegate void EventRecordErrorDelegate(IEventRecordError^ error);
+
+    delegate void EventNativeDelegate(const EVENT_RECORD&, const krabs::trace_context&);
+
+    delegate void EventErrorNativeDelegate(const EVENT_RECORD&, const std::string&);
+
+    ref class CallbackBridge {
+    private:
+
+        EventNativeDelegate^ eventDelegateKeepAlive_;
+        EventErrorNativeDelegate^ errorDelegateKeepAlive_;
+        EventRecordMetadata^ metadata_;
+        EventRecord^ record_;
+        EventRecordError^ error_;
+
+        EventRecordMetadata^ CreateMetadata(const EVENT_RECORD& record);
+        EventRecord^ CreateRecord(const EVENT_RECORD& record, const krabs::schema& schema, krabs::parser& parser);
+        EventRecordError^ CreateError(const std::string& error_message, const EVENT_RECORD& record);
+
+        void EventNotification(const EVENT_RECORD& record, const krabs::trace_context& trace_context);
+        void ErrorNotification(const EVENT_RECORD& record, const std::string& error_message);
+
+    public:
+        IEventRecordMetadataDelegate^ OnMetadata;
+        IEventRecordDelegate^ OnEvent;
+        EventRecordErrorDelegate^ OnError;
+
+        krabs::c_provider_callback GetOnEventBridge()
+        {
+            if (!eventDelegateKeepAlive_)
+                eventDelegateKeepAlive_ = gcnew EventNativeDelegate(this, &CallbackBridge::EventNotification);
+            return (krabs::c_provider_callback)Marshal::GetFunctionPointerForDelegate(eventDelegateKeepAlive_).ToPointer();
+        }
+
+        krabs::c_provider_error_callback GetOnErrorBridge()
+        {
+            if (!errorDelegateKeepAlive_)
+                errorDelegateKeepAlive_ = gcnew EventErrorNativeDelegate(this, &CallbackBridge::ErrorNotification);
+            return (krabs::c_provider_error_callback)Marshal::GetFunctionPointerForDelegate(errorDelegateKeepAlive_).ToPointer();
+        }
+    };
+
+    EventRecordMetadata^ CallbackBridge::CreateMetadata(const EVENT_RECORD& record)
+    {
+        auto value = metadata_;
+        if (!value)
+            return metadata_ = gcnew EventRecordMetadata(record);
+
+        value->Update(record);
+        return value;
+    }
+
+    EventRecord^ CallbackBridge::CreateRecord(const EVENT_RECORD& record, const krabs::schema& schema, krabs::parser& parser)
+    {
+        auto value = record_;
+        if (!value) 
+            return record_ = gcnew EventRecord(record, schema, parser);
+
+        value->Update(record, schema, parser);
+        return value;
+    }
+
+    EventRecordError^ CallbackBridge::CreateError(const std::string& error_message, const EVENT_RECORD& record)
+    {
+        auto msg = gcnew String(error_message.c_str());
+        auto value = error_;
+        if (!value)
+            return error_ = gcnew EventRecordError(msg, gcnew EventRecordMetadata(record));
+
+        value->Update(msg, record);
+        return value;
+    }
+
+    void CallbackBridge::EventNotification(const EVENT_RECORD& record, const krabs::trace_context& trace_context)
+    {
+        auto onMetadata = OnMetadata;
+        if (onMetadata) {
+            auto metadata = CreateMetadata(record);
+
+            onMetadata(metadata);
+        }
+
+        auto onEvent = OnEvent;
+        if (onEvent) {
+            TDHSTATUS status = ERROR_SUCCESS;
+            trace_context.schema_locator.get_event_schema_no_throw(record, status);
+
+            if (status == ERROR_SUCCESS) {
+                krabs::schema schema(record, trace_context.schema_locator);
+                krabs::parser parser(schema);
+                auto evt = CreateRecord(record, schema, parser);
+
+                onEvent(evt);
+            }
+            else {
+                auto error_message = krabs::get_status_and_record_context(status, record);
+                ErrorNotification(record, error_message);
+            }
+        }
+    }
+
+    void CallbackBridge::ErrorNotification(const EVENT_RECORD& record, const std::string& error_message)
+    {
+        auto onError = OnError;
+        if (onError) {
+            auto error = CreateError(error_message, record);
+
+            onError(error);
+        }
+    }
+
+#define CombineOrRemoveDelegate(type, target, value, operation) \
+    { \
+        type^ original = target; \
+        type^ comparand; \
+        do \
+        { \
+            comparand = original; \
+            original = (type^)System::Threading::Interlocked::CompareExchange(target, (type^)System::Delegate::operation(comparand, value), comparand); \
+        } while (original != comparand); \
+    } \
+
+#define CombineDelegate(type, target, value) CombineOrRemoveDelegate(type, target, value, Combine)
+#define RemoveDelegate(type, target, value) CombineOrRemoveDelegate(type, target, value, Remove)
+
+} } } }

--- a/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecord.hpp
@@ -40,6 +40,16 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
             , schema_(&schema)
             , parser_(&parser) { }
 
+        /// <summary>
+        /// Updates this instance to point to the specified event record.
+        /// </summary>
+        void Update(const EVENT_RECORD& record, const krabs::schema& schema, krabs::parser& parser)
+        {
+            Update(record);
+            schema_ = &schema;
+            parser_ = &parser;
+        }
+
     public:
 
 #pragma region Schema

--- a/Microsoft.O365.Security.Native.ETW/EventRecordError.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordError.hpp
@@ -15,8 +15,25 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     public ref struct EventRecordError : public IEventRecordError
     {
     private:
-        initonly System::String^ msg_;
-        initonly IEventRecordMetadata^ record_;
+        System::String^ msg_;
+        EventRecordMetadata^ record_;
+
+    internal:
+        EventRecordError(
+            System::String^ message,
+            EventRecordMetadata^ record)
+            : msg_(message)
+            , record_(record)
+        { }
+
+        /// <summary>
+        /// Updates this instance to point to the specified event record.
+        /// </summary>
+        void Update(System::String^ msg, const EVENT_RECORD& record)
+        {
+            msg_ = msg;
+            record_->Update(record);
+        }
 
     public:
         /// <summary>
@@ -39,14 +56,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
                 return record_;
             }
         }
-
-    internal:
-        EventRecordError(
-            System::String^ message,
-            IEventRecordMetadata^ record)
-            : msg_(message)
-            , record_(record)
-        { }
     };
 
 } } } }

--- a/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
+++ b/Microsoft.O365.Security.Native.ETW/EventRecordMetadata.hpp
@@ -26,12 +26,10 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
             : record_(&record)
             , header_(&record.EventHeader) { }
 
-        EventRecordMetadata() { }
-
         /// <summary>
         /// Updates this instance to point to the specified event record.
         /// </summary>
-        virtual void Update(const EVENT_RECORD& record)
+        void Update(const EVENT_RECORD& record)
         {
             record_ = &record;
             header_ = &record.EventHeader;

--- a/Microsoft.O365.Security.Native.ETW/Filtering/EventFilter.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Filtering/EventFilter.hpp
@@ -60,8 +60,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// filter and the event meets the given predicate.
         /// </summary>
         event IEventRecordDelegate^ OnEvent {
-            void add(IEventRecordDelegate^ value) { CombineDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
-            void remove(IEventRecordDelegate^ value) { RemoveDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
+            void add(IEventRecordDelegate^ value) { CombineDelegate(bridge_->OnEvent, value); }
+            void remove(IEventRecordDelegate^ value) { RemoveDelegate(bridge_->OnEvent, value); }
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// but an error occurs handling the record.
         /// </summary>
         event EventRecordErrorDelegate^ OnError {
-            void add(EventRecordErrorDelegate^ value) { CombineDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
-            void remove(EventRecordErrorDelegate^ value) { RemoveDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
+            void add(EventRecordErrorDelegate^ value) { CombineDelegate(bridge_->OnError, value); }
+            void remove(EventRecordErrorDelegate^ value) { RemoveDelegate(bridge_->OnError, value); }
         }
 
     internal:

--- a/Microsoft.O365.Security.Native.ETW/ITrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/ITrace.hpp
@@ -52,11 +52,15 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// <param name="provider">The <see cref="O365::Security::ETW::Provider"/> to enable.</param>
         void Enable(Provider^ provider);
 
+#pragma warning(push)
+#pragma warning(disable: 4947) // Deprecated warning
         /// <summary>
         /// Enables a raw provider for the given user trace.
         /// </summary>
         /// <param name="provider">The <see cref="O365::Security::ETW::RawProvider"/> to enable.</param>
+        [Obsolete("The RawProvider is deprecated. Use the Provider.OnMetadata event instead.")]
         void Enable(RawProvider^ provider);
+#pragma warning(pop)
     };
 
     /// <summary>

--- a/Microsoft.O365.Security.Native.ETW/KernelProvider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/KernelProvider.hpp
@@ -61,8 +61,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// provider.
         /// </summary>
         event IEventRecordMetadataDelegate^ OnMetadata {
-            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
-            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
+            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(bridge_->OnMetadata, value); }
+            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(bridge_->OnMetadata, value); }
         }
 
         /// <summary>
@@ -70,8 +70,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// provider.
         /// </summary>
         event IEventRecordDelegate^ OnEvent {
-            void add(IEventRecordDelegate^ value) { CombineDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
-            void remove(IEventRecordDelegate^ value) { RemoveDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
+            void add(IEventRecordDelegate^ value) { CombineDelegate(bridge_->OnEvent, value); }
+            void remove(IEventRecordDelegate^ value) { RemoveDelegate(bridge_->OnEvent, value); }
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// but an error occurs handling the record.
         /// </summary>
         event EventRecordErrorDelegate^ OnError {
-            void add(EventRecordErrorDelegate^ value) { CombineDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
-            void remove(EventRecordErrorDelegate^ value) { RemoveDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
+            void add(EventRecordErrorDelegate^ value) { CombineDelegate(bridge_->OnError, value); }
+            void remove(EventRecordErrorDelegate^ value) { RemoveDelegate(bridge_->OnError, value); }
         }
 
         /// <summary>

--- a/Microsoft.O365.Security.Native.ETW/KernelProvider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/KernelProvider.hpp
@@ -6,8 +6,7 @@
 #include <krabs.hpp>
 #include <krabs/perfinfo_groupmask.hpp>
 
-#include "EventRecord.hpp"
-#include "EventRecordMetadata.hpp"
+#include "Callbacks.hpp"
 #include "Guid.hpp"
 #include "NativePtr.hpp"
 #include "Filtering/EventFilter.hpp"
@@ -47,11 +46,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         KernelProvider(System::Guid id, PERFINFO_MASK mask);
 
         /// <summary>
-        /// Destructs a KernelProvider.
-        /// </summary>
-        ~KernelProvider();
-
-        /// <summary>
         /// Adds a new EventFilter to the provider.
         /// </summary>
         /// <param name="filter">
@@ -66,13 +60,28 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// An event that is invoked when an ETW event is fired in this
         /// provider.
         /// </summary>
-        event IEventRecordDelegate^ OnEvent;
+        event IEventRecordMetadataDelegate^ OnMetadata {
+            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
+            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
+        }
+
+        /// <summary>
+        /// An event that is invoked when an ETW event is fired in this
+        /// provider.
+        /// </summary>
+        event IEventRecordDelegate^ OnEvent {
+            void add(IEventRecordDelegate^ value) { CombineDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
+            void remove(IEventRecordDelegate^ value) { RemoveDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
+        }
 
         /// <summary>
         /// An event that is invoked when an ETW event is received
         /// but an error occurs handling the record.
         /// </summary>
-        event EventRecordErrorDelegate^ OnError;
+        event EventRecordErrorDelegate^ OnError {
+            void add(EventRecordErrorDelegate^ value) { CombineDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
+            void remove(EventRecordErrorDelegate^ value) { RemoveDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
+        }
 
         /// <summary>
         /// Retrieves the GUID associated with this provider
@@ -89,17 +98,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
             }
         }
 
-
     internal:
-        void EventNotification(const EVENT_RECORD &, const krabs::trace_context &);
-
-    internal:
-        delegate void NativeHookDelegate(const EVENT_RECORD &, const krabs::trace_context &);
-
-        NativeHookDelegate ^del_;
         NativePtr<krabs::kernel_provider> provider_;
-        GCHandle delegateHookHandle_;
-        GCHandle delegateHandle_;
+        CallbackBridge^ bridge_ = gcnew CallbackBridge();
+
+        void RegisterCallbacks();
     };
 
     // Implementation
@@ -108,54 +111,19 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline KernelProvider::KernelProvider(unsigned int flags, System::Guid id)
     : provider_(flags, ConvertGuid(id))
     {
-        del_ = gcnew NativeHookDelegate(this, &KernelProvider::EventNotification);
-        delegateHandle_ = GCHandle::Alloc(del_);
-        auto bridged = Marshal::GetFunctionPointerForDelegate(del_);
-        delegateHookHandle_ = GCHandle::Alloc(bridged);
-
-        provider_->add_on_event_callback((krabs::c_provider_callback)bridged.ToPointer());
+        RegisterCallbacks();
     }
 
     inline KernelProvider::KernelProvider(System::Guid id, PERFINFO_MASK mask)
         : provider_(ConvertGuid(id), mask)
     {
-        del_ = gcnew NativeHookDelegate(this, &KernelProvider::EventNotification);
-        delegateHandle_ = GCHandle::Alloc(del_);
-        auto bridged = Marshal::GetFunctionPointerForDelegate(del_);
-        delegateHookHandle_ = GCHandle::Alloc(bridged);
-
-        provider_->add_on_event_callback((krabs::c_provider_callback)bridged.ToPointer());
+        RegisterCallbacks();
     }
 
-    inline KernelProvider::~KernelProvider()
+    inline void KernelProvider::RegisterCallbacks()
     {
-        if (delegateHandle_.IsAllocated)
-        {
-            delegateHandle_.Free();
-        }
-
-        if (delegateHookHandle_.IsAllocated)
-        {
-            delegateHookHandle_.Free();
-        }
-    }
-
-    inline void KernelProvider::EventNotification(const EVENT_RECORD &record, const krabs::trace_context &trace_context)
-    {
-        try
-        {
-            krabs::schema schema(record, trace_context.schema_locator);
-            krabs::parser parser(schema);
-
-            OnEvent(gcnew EventRecord(record, schema, parser));
-        }
-        catch (const krabs::could_not_find_schema& ex)
-        {
-            auto msg = gcnew String(ex.what());
-            auto metadata = gcnew EventRecordMetadata(record);
-
-            OnError(gcnew EventRecordError(msg, metadata));
-        }
+        provider_->add_on_event_callback(bridge_->GetOnEventBridge());
+        provider_->add_on_error_callback(bridge_->GetOnErrorBridge());
     }
 
 } } } }

--- a/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/KernelTrace.hpp
@@ -150,18 +150,41 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         ///     KernelTrace trace = new KernelTrace();
         ///     trace.SetDefaultEventCallback((record) => { ... });
         /// </example>
-        virtual void SetDefaultEventCallback(IEventRecordDelegate^ callback);
+        [Obsolete("This method is deprecated. Use the DefaultMetadata/DefaultEvent/DefaultError event instead.")]
+        virtual void SetDefaultEventCallback(IEventRecordDelegate^ callback) { DefaultEvent = callback; }
+
+        /// <summary>
+        /// An event is fired which has no corresponding provider.
+        /// provider.
+        /// </summary>
+        property IEventRecordMetadataDelegate^ DefaultMetadata {
+            IEventRecordMetadataDelegate^ get() { return bridge_->OnMetadata; }
+            void set(IEventRecordMetadataDelegate^ value) { bridge_->OnMetadata = value; }
+        }
+
+        /// <summary>
+        /// An event is fired which has no corresponding provider.
+        /// provider.
+        /// </summary>
+        property IEventRecordDelegate^ DefaultEvent {
+            IEventRecordDelegate^ get() { return bridge_->OnEvent; }
+            void set(IEventRecordDelegate^ value) { bridge_->OnEvent = value; }
+        }
+
+        /// <summary>
+        /// An event is fired when failed to fire <see cref="DefaultEvent"/>.
+        /// </summary>
+        property EventRecordErrorDelegate^ DefaultError {
+            EventRecordErrorDelegate^ get() { return bridge_->OnError; }
+            void set(EventRecordErrorDelegate^ value) { bridge_->OnError = value; }
+        }
 
     internal:
         bool disposed_ = false;
         O365::Security::ETW::NativePtr<krabs::kernel_trace> trace_;
+        CallbackBridge^ bridge_ = gcnew CallbackBridge();
 
-        IEventRecordDelegate^ callback_;
-        void EventNotification(const EVENT_RECORD&, const krabs::trace_context&);
-        delegate void NativeHookDelegate(const EVENT_RECORD&, const krabs::trace_context&);
-        NativeHookDelegate^ del_;
-        GCHandle delegateHandle_;
-        GCHandle delegateHookHandle_;
+        void RegisterCallbacks();
     };
 
     // Implementation
@@ -169,7 +192,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
     inline KernelTrace::KernelTrace()
         : trace_(new krabs::kernel_trace())
-    { }
+    {
+        RegisterCallbacks();
+    }
 
     inline KernelTrace::~KernelTrace()
     {
@@ -179,16 +204,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
 
         Stop();
         disposed_ = true;
-
-        if (delegateHandle_.IsAllocated)
-        {
-            delegateHandle_.Free();
-        }
-
-        if (delegateHookHandle_.IsAllocated)
-        {
-            delegateHookHandle_.Free();
-        }
     }
 
     inline KernelTrace::KernelTrace(String ^name)
@@ -196,6 +211,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     {
         std::wstring nativeName = msclr::interop::marshal_as<std::wstring>(name);
         trace_.Swap(O365::Security::ETW::NativePtr<krabs::kernel_trace>(nativeName));
+        RegisterCallbacks();
     }
 
     inline void KernelTrace::Enable(O365::Security::ETW::KernelProvider ^provider)
@@ -234,24 +250,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         ExecuteAndConvertExceptions(return TraceStats(trace_->query_stats()));
     }
 
-    inline void KernelTrace::SetDefaultEventCallback(IEventRecordDelegate^ callback)
+    inline void KernelTrace::RegisterCallbacks()
     {
-        callback_ = callback;
-
-        if (!delegateHandle_.IsAllocated) {
-            del_ = gcnew NativeHookDelegate(this, &KernelTrace::EventNotification);
-            delegateHandle_ = GCHandle::Alloc(del_);
-            auto bridged = Marshal::GetFunctionPointerForDelegate(del_);
-            delegateHookHandle_ = GCHandle::Alloc(bridged);
-            ExecuteAndConvertExceptions((void)trace_->set_default_event_callback((krabs::c_provider_callback)bridged.ToPointer()));
-        }
-    }
-
-    inline void KernelTrace::EventNotification(const EVENT_RECORD& record, const krabs::trace_context& trace_context)
-    {
-            krabs::schema schema(record, trace_context.schema_locator);
-            krabs::parser parser(schema);
-            callback_(gcnew EventRecord(record, schema, parser));
+        trace_->set_default_event_callback(bridge_->GetOnEventBridge());
     }
 
 } } } }

--- a/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj
+++ b/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj
@@ -358,6 +358,7 @@
     <ClCompile Include="ETWLib.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Callbacks.hpp" />
     <ClInclude Include="Conversions.hpp" />
     <ClInclude Include="Errors.hpp" />
     <ClInclude Include="EventRecordError.hpp" />

--- a/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj.filters
+++ b/Microsoft.O365.Security.Native.ETW/Microsoft.O365.Security.Native.ETW.vcxproj.filters
@@ -122,6 +122,9 @@
     <ClInclude Include="IEventRecordError.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Callbacks.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".nuget\NuGet.Config">

--- a/Microsoft.O365.Security.Native.ETW/Provider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Provider.hpp
@@ -172,8 +172,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// provider.
         /// </summary>
         event IEventRecordMetadataDelegate^ OnMetadata {
-            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
-            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
+            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(bridge_->OnMetadata, value); }
+            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(bridge_->OnMetadata, value); }
         }
 
         /// <summary>
@@ -181,8 +181,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// provider.
         /// </summary>
         event IEventRecordDelegate^ OnEvent {
-            void add(IEventRecordDelegate^ value) { CombineDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
-            void remove(IEventRecordDelegate^ value) { RemoveDelegate(IEventRecordDelegate, bridge_->OnEvent, value); }
+            void add(IEventRecordDelegate^ value) { CombineDelegate(bridge_->OnEvent, value); }
+            void remove(IEventRecordDelegate^ value) { RemoveDelegate(bridge_->OnEvent, value); }
         }
 
         /// <summary>
@@ -190,8 +190,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// but an error occurs handling the record.
         /// </summary>
         event EventRecordErrorDelegate^ OnError {
-            void add(EventRecordErrorDelegate^ value) { CombineDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
-            void remove(EventRecordErrorDelegate^ value) { RemoveDelegate(EventRecordErrorDelegate, bridge_->OnError, value); }
+            void add(EventRecordErrorDelegate^ value) { CombineDelegate(bridge_->OnError, value); }
+            void remove(EventRecordErrorDelegate^ value) { RemoveDelegate(bridge_->OnError, value); }
         }
 
     internal:

--- a/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
@@ -103,8 +103,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// provider.
         /// </summary>
         event IEventRecordMetadataDelegate^ OnEvent {
-            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
-            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
+            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(bridge_->OnMetadata, value); }
+            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(bridge_->OnMetadata, value); }
         }
 
     internal:

--- a/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
+++ b/Microsoft.O365.Security.Native.ETW/RawProvider.hpp
@@ -5,22 +5,18 @@
 
 #include <krabs.hpp>
 
-#include "EventRecord.hpp"
-#include "EventRecordMetadata.hpp"
+#include "Callbacks.hpp"
 #include "Guid.hpp"
 #include "NativePtr.hpp"
 #include "Filtering/EventFilter.hpp"
+
+#pragma warning(push)
+#pragma warning(disable: 4947) // Deprecated warning
 
 using namespace System;
 using namespace System::Runtime::InteropServices;
 
 namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
-
-    /// <summary>
-    /// Delegate called when a new ETW <see cref="O365::Security::ETW::EventRecordMetadata"/> is received.
-    /// </summary>
-    public delegate void IEventRecordMetadataDelegate(
-        O365::Security::ETW::IEventRecordMetadata^ record);
 
     ref class UserTrace;
 
@@ -30,6 +26,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     /// so it can be used to access events without a registered schema.
     /// </summary>
     /// <seealso cref="O365::Security::ETW::Provider"/>
+    [Obsolete("This class is deprecated. Use the Provider.OnMetadata event instead.")]
     public ref class RawProvider {
     public:
         /// <summary>
@@ -51,11 +48,6 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// <param name="providerName">the friendly name of the provider to enable</param>
         /// <seealso cref="O365::Security::ETW::Provider"/>
         RawProvider(String^ providerName);
-
-        /// <summary>
-        /// Destructs a RawProvider.
-        /// </summary>
-        ~RawProvider();
 
         /// <summary>
         /// Represents the "any" value on the provider's options, where
@@ -110,20 +102,16 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// An event that is invoked when an ETW event is fired in this
         /// provider.
         /// </summary>
-        event IEventRecordMetadataDelegate^ OnEvent;
+        event IEventRecordMetadataDelegate^ OnEvent {
+            void add(IEventRecordMetadataDelegate^ value) { CombineDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
+            void remove(IEventRecordMetadataDelegate^ value) { RemoveDelegate(IEventRecordMetadataDelegate, bridge_->OnMetadata, value); }
+        }
 
     internal:
-        void EventNotification(const EVENT_RECORD &);
-
-    internal:
-        delegate void NativeHookDelegate(const EVENT_RECORD &);
-
-        NativeHookDelegate ^del_;
         NativePtr<krabs::provider<>> provider_;
-        GCHandle delegateHookHandle_;
-        GCHandle delegateHandle_;
-        EventRecordMetadata^ data_;
-        void SetUpProvider();
+        CallbackBridge^ bridge_ = gcnew CallbackBridge();
+
+        void RegisterCallbacks();
     };
 
     // Implementation
@@ -132,44 +120,20 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline RawProvider::RawProvider(System::Guid id)
         : provider_(ConvertGuid(id))
     {
-        SetUpProvider();
+        RegisterCallbacks();
     }
 
     inline RawProvider::RawProvider(String^ providerName)
         : provider_(msclr::interop::marshal_as<std::wstring>(providerName))
     {
-        SetUpProvider();
+        RegisterCallbacks();
     }
 
-    inline void RawProvider::SetUpProvider()
+    inline void RawProvider::RegisterCallbacks()
     {
-        del_ = gcnew NativeHookDelegate(this, &RawProvider::EventNotification);
-        delegateHandle_ = GCHandle::Alloc(del_);
-        auto bridged = Marshal::GetFunctionPointerForDelegate(del_);
-        delegateHookHandle_ = GCHandle::Alloc(bridged);
-
-        provider_->add_on_event_callback((krabs::c_provider_callback)bridged.ToPointer());
-
-        data_ = gcnew EventRecordMetadata();
+        provider_->add_on_event_callback(bridge_->GetOnEventBridge());
     }
 
-    inline RawProvider::~RawProvider()
-    {
-        if (delegateHandle_.IsAllocated)
-        {
-            delegateHandle_.Free();
-        }
-
-        if (delegateHookHandle_.IsAllocated)
-        {
-            delegateHookHandle_.Free();
-        }
-    }
-
-    inline void RawProvider::EventNotification(const EVENT_RECORD &record)
-    {
-        data_->Update(record);
-
-        OnEvent(data_);
-    }
 } } } }
+
+#pragma warning(pop)

--- a/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
+++ b/Microsoft.O365.Security.Native.ETW/UserTrace.hpp
@@ -61,6 +61,8 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// </example>
         virtual void Enable(O365::Security::ETW::Provider ^provider);
 
+#pragma warning(push)
+#pragma warning(disable: 4947) // Deprecated warning
         /// <summary>
         /// Enables a raw provider for the given user trace.
         /// </summary>
@@ -71,7 +73,9 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         ///     Provider provider = new RawProvider(powershell);
         ///     trace.Enable(provider);
         /// </example>
+        [Obsolete("The RawProvider is deprecated. Use the Provider.OnMetadata event instead.")]
         virtual void Enable(O365::Security::ETW::RawProvider ^provider);
+#pragma warning(pop)
 
         /// <summary>
         /// Sets the trace properties for a session.
@@ -150,9 +154,38 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// <returns>the <see cref="O365::Security::ETW::TraceStats"/> for the current trace object</returns>
         virtual TraceStats QueryStats();
 
+        /// <summary>
+        /// An event is fired which has no corresponding provider.
+        /// provider.
+        /// </summary>
+        property IEventRecordMetadataDelegate^ DefaultMetadata {
+            IEventRecordMetadataDelegate^ get() { return bridge_->OnMetadata; }
+            void set(IEventRecordMetadataDelegate^ value) { bridge_->OnMetadata = value; }
+        }
+
+        /// <summary>
+        /// An event is fired which has no corresponding provider.
+        /// provider.
+        /// </summary>
+        property IEventRecordDelegate^ DefaultEvent {
+            IEventRecordDelegate^ get() { return bridge_->OnEvent; }
+            void set(IEventRecordDelegate^ value) { bridge_->OnEvent = value; }
+        }
+
+        /// <summary>
+        /// An event is fired when failed to fire <see cref="DefaultEvent"/>.
+        /// </summary>
+        property EventRecordErrorDelegate^ DefaultError {
+            EventRecordErrorDelegate^ get() { return bridge_->OnError; }
+            void set(EventRecordErrorDelegate^ value) { bridge_->OnError = value; }
+        }
+
     internal:
         bool disposed_ = false;
         O365::Security::ETW::NativePtr<krabs::user_trace> trace_;
+        CallbackBridge^ bridge_ = gcnew CallbackBridge();
+
+        void RegisterCallbacks();
     };
 
     // Implementation
@@ -161,6 +194,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline UserTrace::UserTrace()
         : trace_(new krabs::user_trace())
     {
+        RegisterCallbacks();
     }
 
     inline UserTrace::~UserTrace()
@@ -178,6 +212,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     {
         std::wstring nativeName = msclr::interop::marshal_as<std::wstring>(name);
         trace_.Swap(O365::Security::ETW::NativePtr<krabs::user_trace>(nativeName));
+        RegisterCallbacks();
     }
 
     inline void UserTrace::Enable(O365::Security::ETW::Provider ^provider)
@@ -185,10 +220,13 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         return trace_->enable(*provider->provider_);
     }
 
+#pragma warning(push)
+#pragma warning(disable: 4947) // Deprecated warning
     inline void UserTrace::Enable(O365::Security::ETW::RawProvider ^provider)
     {
         return trace_->enable(*provider->provider_);
     }
+#pragma warning(pop)
 
     inline void UserTrace::SetTraceProperties(EventTraceProperties ^properties)
     {
@@ -219,6 +257,11 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
     inline TraceStats UserTrace::QueryStats()
     {
         ExecuteAndConvertExceptions(return TraceStats(trace_->query_stats()));
+    }
+
+    inline void UserTrace::RegisterCallbacks()
+    {
+        trace_->set_default_event_callback(bridge_->GetOnEventBridge());
     }
 
 } } } }

--- a/examples/ManagedExamples/KernelTrace002.cs
+++ b/examples/ManagedExamples/KernelTrace002.cs
@@ -47,10 +47,10 @@ namespace ManagedExamples
             // You'll also likely receive the EventTrace_Header and any HWConfig events here.
             //  * https://docs.microsoft.com/en-us/windows/win32/etw/eventtrace-header
             //  * https://docs.microsoft.com/en-us/windows/win32/etw/hwconfig
-            trace.SetDefaultEventCallback((record) =>
+            trace.DefaultEvent += (record) =>
             {
                 Console.WriteLine($"{record.ProviderId} provider={record.ProviderName} task_name={record.TaskName} opcode={record.Opcode} opcode_name={record.OpcodeName}");
-            });
+            };
             trace.Enable(hiveProvider);
 
             trace.Start();

--- a/krabs/krabs/ut.hpp
+++ b/krabs/krabs/ut.hpp
@@ -238,12 +238,14 @@ namespace krabs { namespace details {
         // for MOF providers, EventHeader.Provider is the *Message* GUID
         // we need to ask TDH for event information in order to determine the
         // correct provider to pass this event to
-        auto schema = get_event_schema_from_tdh(record);
-        auto eventInfo = reinterpret_cast<PTRACE_EVENT_INFO>(schema.get());
-        for (auto& provider : trace.providers_) {
-            if (eventInfo->ProviderGuid == provider.get().guid_) {
-                provider.get().on_event(record, trace.context_);
-                return;
+        TDHSTATUS status = ERROR_SUCCESS;
+        auto schema = trace.context_.schema_locator.get_event_schema_no_throw(record, status);
+        if (status == ERROR_SUCCESS) {
+            for (auto& provider : trace.providers_) {
+                if (schema->ProviderGuid == provider.get().guid_) {
+                    provider.get().on_event(record, trace.context_);
+                    return;
+                }
             }
         }
 

--- a/tests/ManagedETWTests/describe_Proxy.cs
+++ b/tests/ManagedETWTests/describe_Proxy.cs
@@ -33,7 +33,54 @@ namespace EtwTestsCS
         }
 
         [TestMethod]
-        public void it_should_raise_OnEvent_for_raw_provider_on_user_trace()
+        public void it_should_raise_OnMetadata_for_user_trace()
+        {
+            var called = false;
+
+            var trace = new UserTrace();
+            var proxy = new Proxy(trace);
+
+            var provider = new Provider(PowerShellEvent.ProviderId);
+            provider.OnMetadata += e => { called = true; };
+
+            trace.Enable(provider);
+            proxy.PushEvent(PowerShellEvent.CreateRecord("user data", "context info", "payload"));
+
+            Assert.IsTrue(called, "proxy call raised on event");
+        }
+
+        [TestMethod]
+        public void it_should_raise_DefaultEvent_for_user_trace()
+        {
+            var called = false;
+
+            var trace = new UserTrace();
+            var proxy = new Proxy(trace);
+
+            trace.DefaultEvent += e => { called = true; };
+
+            proxy.PushEvent(PowerShellEvent.CreateRecord("user data", "context info", "payload"));
+
+            Assert.IsTrue(called, "proxy call raised on event");
+        }
+
+        [TestMethod]
+        public void it_should_raise_DefaultMetadata_for_user_trace()
+        {
+            var called = false;
+
+            var trace = new UserTrace();
+            var proxy = new Proxy(trace);
+
+            trace.DefaultMetadata += e => { called = true; };
+
+            proxy.PushEvent(PowerShellEvent.CreateRecord("user data", "context info", "payload"));
+
+            Assert.IsTrue(called, "proxy call raised on event");
+        }
+
+        [TestMethod, Obsolete]
+        public void it_should_raise_OnMetadata_for_provider_on_user_trace()
         {
             var called = false;
 
@@ -61,6 +108,53 @@ namespace EtwTestsCS
             provider.OnEvent += e => { called = true; };
 
             trace.Enable(provider);
+            proxy.PushEvent(ImageLoadEvent.CreateRecord(123, "file.exe"));
+
+            Assert.IsTrue(called, "proxy call raised on event");
+        }
+
+        [TestMethod]
+        public void it_should_raise_OnMetadata_for_kernel_trace()
+        {
+            var called = false;
+
+            var trace = new KernelTrace();
+            var proxy = new Proxy(trace);
+
+            var provider = new ImageLoadProvider();
+            provider.OnMetadata += e => { called = true; };
+
+            trace.Enable(provider);
+            proxy.PushEvent(ImageLoadEvent.CreateRecord(123, "file.exe"));
+
+            Assert.IsTrue(called, "proxy call raised on event");
+        }
+
+        [TestMethod]
+        public void it_should_raise_DefaultEvent_for_kernel_trace()
+        {
+            var called = false;
+
+            var trace = new KernelTrace();
+            var proxy = new Proxy(trace);
+
+            trace.DefaultEvent += e => { called = true; };
+
+            proxy.PushEvent(ImageLoadEvent.CreateRecord(123, "file.exe"));
+
+            Assert.IsTrue(called, "proxy call raised on event");
+        }
+
+        [TestMethod]
+        public void it_should_raise_DefaultMetadata_for_kernel_trace()
+        {
+            var called = false;
+
+            var trace = new KernelTrace();
+            var proxy = new Proxy(trace);
+
+            trace.DefaultMetadata += e => { called = true; };
+
             proxy.PushEvent(ImageLoadEvent.CreateRecord(123, "file.exe"));
 
             Assert.IsTrue(called, "proxy call raised on event");


### PR DESCRIPTION
1. Unify. NET wrappers of callbacks to simplify logic
2. Add no throw version of get_event_schema and also cache error status
3. Merge the ability of RawProvider to Provider to reduce the fragmentation of code functionality
4. Remove invalid GCHandle usages
5. Use schema_locator.get_event_schema_no_throw in ut::forward_events to avoid exceptions
6. Check status code instead of throw then catch exceptions to gain more performance
7. Also cache EventRecord and EventRecordError objects like EventRecordMetadata to reduce allocations

Closes https://github.com/microsoft/krabsetw/issues/252
Closes https://github.com/microsoft/krabsetw/issues/253