### PR TITLE
Disable MSIL generation for krabs .NET wrapper native part to significantly reduce binary size

### DIFF
--- a/Microsoft.O365.Security.Native.ETW/Filtering/Fluent.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Filtering/Fluent.hpp
@@ -99,7 +99,7 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW {
         /// <returns>a predicate that matches events of the specified UInt32 property</returns>
         static Predicate ^IsUInt32(String ^propertyName, UInt32 value)
         {
-            return gcnew Predicate(krabs::predicates::property_is<UInt32>(
+            return gcnew Predicate(krabs::predicates::property_is<uint32_t>(
                 msclr::interop::marshal_as<std::wstring>(propertyName),
                 value));
         }

--- a/Microsoft.O365.Security.Native.ETW/Testing/RecordBuilder.hpp
+++ b/Microsoft.O365.Security.Native.ETW/Testing/RecordBuilder.hpp
@@ -149,22 +149,22 @@ namespace Microsoft { namespace O365 { namespace Security { namespace ETW { name
     inline void RecordBuilder::AddValue(System::String^ name, T value)
     {
         if (T::typeid == Int16::typeid)
-            AddValueInternal(name, (Int16)value);
+            AddValueInternal(name, (int16_t)value);
 
         else if (T::typeid == UInt16::typeid)
-            AddValueInternal(name, (UInt16)value);
+            AddValueInternal(name, (uint16_t)value);
 
         else if (T::typeid == Int32::typeid)
-            AddValueInternal(name, (Int32)value);
+            AddValueInternal(name, (int32_t)value);
 
         else if (T::typeid == UInt32::typeid)
-            AddValueInternal(name, (UInt32)value);
+            AddValueInternal(name, (uint32_t)value);
 
         else if (T::typeid == Int64::typeid)
-            AddValueInternal(name, (Int64)value);
+            AddValueInternal(name, (int64_t)value);
 
         else if (T::typeid == UInt64::typeid)
-            AddValueInternal(name, (UInt64)value);
+            AddValueInternal(name, (uint64_t)value);
 
         else
         {

--- a/krabs/krabs.hpp
+++ b/krabs/krabs.hpp
@@ -26,6 +26,8 @@
 #pragma warning(disable: 4634) // DocXml comment warnings in native C++
 #pragma warning(disable: 4635) // DocXml comment warnings in native C++
 
+#pragma managed(push, off)
+
 #include "krabs/compiler_check.hpp"
 #include "krabs/ut.hpp"
 #include "krabs/kt.hpp"
@@ -57,5 +59,7 @@
 #include "krabs/filtering/comparers.hpp"
 #include "krabs/filtering/predicates.hpp"
 #include "krabs/filtering/event_filter.hpp"
+
+#pragma managed(pop)
 
 #pragma warning(pop)


### PR DESCRIPTION
original(.net462): 2473kb
new(.net462): 954kb