### PR TITLE
Fix GenerateRefAssemblies.ps1 error due to breaking change with Refasmer

### DIFF
--- a/GenerateRefAssemblies.ps1
+++ b/GenerateRefAssemblies.ps1
@@ -26,7 +26,7 @@ $platforms | ForEach-Object {
             $targetAssembly = ".\krabs\$platform\$configuration\$targetFramework\$targetAssemblyName"
             if (($generated -notcontains $targetFramework) -and (Test-Path $targetAssembly)) {
                 Write-Host "Generating reference assembly for $targetAssembly"
-                & $refasmer -v -O "ref\$targetFramework" -c $targetAssembly
+                & $refasmer -v --omit-non-api-members=false -O "ref\$targetFramework" -c $targetAssembly
                 if (Test-Path ".\ref\$targetFramework\$targetAssemblyName") {
                     Write-Host "Reference assembly for $targetFramework generated successfully."
                     $generated += $targetFramework

--- a/Microsoft.O365.Security.Native.ETW/AssemblyInfo.cpp
+++ b/Microsoft.O365.Security.Native.ETW/AssemblyInfo.cpp
@@ -32,7 +32,7 @@ using namespace System::Security::Permissions;
 // You can specify all the value or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly:AssemblyVersionAttribute("4.4.4.0")];
+[assembly:AssemblyVersionAttribute("4.4.5.0")];
 
 [assembly:ComVisible(false)];
 

--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.4.4</version>
+        <version>4.4.5</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,10 +12,8 @@
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</summary>
         <releaseNotes>
-            Version 4.4.4:
-              - Revamped callback infrastructure.
-              - Faster provider enumeration.
-              - Support disabling WPP and MOF handling.
+            Version 4.4.5:
+              - Fixes error with Refasmer when generating reference assemblies
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.4.4</version>
+        <version>4.4.5</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,10 +12,8 @@
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</summary>
         <releaseNotes>
-            Version 4.4.4:
-              - Revamped callback infrastructure.
-              - Faster provider enumeration.
-              - Support disabling WPP and MOF handling.
+            Version 4.4.5:
+              - Fixes error with Refasmer when generating reference assemblies
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.4.4</version>
+        <version>4.4.5</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,10 +12,8 @@
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
         <releaseNotes>
-            Version 4.4.4:
-              - Revamped callback infrastructure.
-              - Faster provider enumeration.
-              - Support disabling WPP and MOF handling.
+            Version 4.4.5:
+              - Fixes error with Refasmer when generating reference assemblies
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />


### PR DESCRIPTION
Fix GenerateRefAssemblies.ps1 error due to breaking change with Refasmer and bump nuget version