### PR TITLE
Parser performance

### DIFF
--- a/O365.Security.Native.ETW.Debug.nuspec
+++ b/O365.Security.Native.ETW.Debug.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW.Debug</id>
-        <version>4.4.7</version>
+        <version>4.4.8</version>
         <title>Microsoft.O365.Security.Native.ETW Debug - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,9 @@
         <description>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</description>
         <summary>Microsoft.O365.Security.Native.ETW Debug is a managed wrapper around the krabsetw ETW library. This is the Debug build.</summary>
         <releaseNotes>
-            Version 4.4.7:
-              - Add process_start_key() to read ProcessStartKey from extended data
+            Version 4.4.8:
+              - Optimize parser property lookup with persistent name-to-index map
+              - Use std::wstring_view for parser property name parameters
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/O365.Security.Native.ETW.nuspec
+++ b/O365.Security.Native.ETW.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Native.ETW</id>
-        <version>4.4.7</version>
+        <version>4.4.8</version>
         <title>Microsoft.O365.Security.Native.ETW - managed wrappers for krabsetw</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,9 @@
         <description>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</description>
         <summary>Microsoft.O365.Security.Native.ETW is a managed wrapper around the krabsetw ETW library.</summary>
         <releaseNotes>
-            Version 4.4.7:
-              - Add process_start_key() to read ProcessStartKey from extended data
+            Version 4.4.8:
+              - Optimize parser property lookup with persistent name-to-index map
+              - Use std::wstring_view for parser property name parameters
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />

--- a/krabs/krabs/parser.hpp
+++ b/krabs/krabs/parser.hpp
@@ -76,7 +76,7 @@ namespace krabs {
          * </remarks>
          */
         template <typename T>
-        bool try_parse(const std::wstring &name, T &out);
+        bool try_parse(std::wstring_view name, T &out);
 
         /**
          * <summary>
@@ -85,13 +85,13 @@ namespace krabs {
          * </summary>
          */
         template <typename T>
-        T parse(const std::wstring &name);
+        T parse(std::wstring_view name);
 
         template <typename Adapter>
-        auto view_of(const std::wstring &name, Adapter &adapter) -> collection_view<typename Adapter::const_iterator>;
+        auto view_of(std::wstring_view name, Adapter &adapter) -> collection_view<typename Adapter::const_iterator>;
 
     private:
-        property_info find_property(const std::wstring &name);
+        property_info find_property(std::wstring_view name);
         void cache_property(ULONG index, property_info info);
 
     private:
@@ -122,7 +122,7 @@ namespace krabs {
         return property_iterator(schema_);
     }
 
-    inline property_info parser::find_property(const std::wstring &name)
+    inline property_info parser::find_property(std::wstring_view name)
     {
         // A schema contains a collection of properties that are keyed by name.
         // These properties are stored in a blob of bytes that needs to be
@@ -139,7 +139,7 @@ namespace krabs {
         if (pPropertyNames_) {
             // Fast path: use the persistent name to index map shared across
             // all events of the same type.
-            auto it = pPropertyNames_->find(std::wstring_view(name));
+            auto it = pPropertyNames_->find(name);
             if (it != pPropertyNames_->end()) {
                 index = it->second;
             }
@@ -245,7 +245,7 @@ namespace krabs {
     // ------------------------------------------------------------------------
 
     template <typename T>
-    bool parser::try_parse(const std::wstring &name, T &out)
+    bool parser::try_parse(std::wstring_view name, T &out)
     {
         try {
             out = parse<T>(name);
@@ -270,7 +270,7 @@ namespace krabs {
     // ------------------------------------------------------------------------
 
     template <typename T>
-    T parser::parse(const std::wstring &name)
+    T parser::parse(std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -286,7 +286,7 @@ namespace krabs {
     }
 
     template<>
-    inline bool parser::parse<bool>(const std::wstring& name)
+    inline bool parser::parse<bool>(std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -298,7 +298,7 @@ namespace krabs {
     }
 
     template <>
-    inline std::wstring parser::parse<std::wstring>(const std::wstring &name)
+    inline std::wstring parser::parse<std::wstring>(std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -312,7 +312,7 @@ namespace krabs {
     }
 
     template <>
-    inline std::string parser::parse<std::string>(const std::wstring &name)
+    inline std::string parser::parse<std::string>(std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -326,7 +326,7 @@ namespace krabs {
     }
 
     template<>
-    inline const counted_string* parser::parse<const counted_string*>(const std::wstring &name)
+    inline const counted_string* parser::parse<const counted_string*>(std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -337,7 +337,7 @@ namespace krabs {
     }
 
     template<>
-    inline binary parser::parse<binary>(const std::wstring &name)
+    inline binary parser::parse<binary>(std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -349,7 +349,7 @@ namespace krabs {
 
     template<>
     inline ip_address parser::parse<ip_address>(
-        const std::wstring &name)
+        std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -372,7 +372,7 @@ namespace krabs {
 
     template<>
     inline socket_address parser::parse<socket_address>(
-        const std::wstring &name)
+        std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -384,7 +384,7 @@ namespace krabs {
 
     template<>
     inline sid parser::parse<sid>(
-        const std::wstring& name)
+        std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -422,7 +422,7 @@ namespace krabs {
     }
 
     template<>
-    inline pointer parser::parse<pointer>(const std::wstring& name)
+    inline pointer parser::parse<pointer>(std::wstring_view name)
     {
         auto propInfo = find_property(name);
         throw_if_property_not_found(propInfo);
@@ -436,7 +436,7 @@ namespace krabs {
     // ------------------------------------------------------------------------
 
     template <typename Adapter>
-    auto parser::view_of(const std::wstring &name, Adapter &adapter)
+    auto parser::view_of(std::wstring_view name, Adapter &adapter)
         -> collection_view<typename Adapter::const_iterator>
     {
         auto propInfo = find_property(name);

--- a/krabs/krabs/parser.hpp
+++ b/krabs/krabs/parser.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <cassert>
-#include <deque>
-#include <utility>
 #include <stdexcept>
+#include <string_view>
+#include <vector>
 
 #include <functional>
 
@@ -92,16 +92,17 @@ namespace krabs {
 
     private:
         property_info find_property(const std::wstring &name);
-        void cache_property(const wchar_t *name, property_info info);
+        void cache_property(ULONG index, property_info info);
 
     private:
         const schema &schema_;
         const BYTE *pEndBuffer_;
         BYTE *pBufferIndex_;
         ULONG lastPropertyIndex_;
-
-        // Maintain a mapping from property name to blob data index.
-        std::deque<std::pair<const wchar_t *, property_info>> propertyCache_;
+        // Persistent name to index map shared across all events of the same type.
+        const property_name_map *pPropertyNames_;
+        // Maintain a mapping from property index to blob data location.
+        std::vector<property_info> propertyCache_;
     };
 
     // Implementation
@@ -112,6 +113,8 @@ namespace krabs {
     , pEndBuffer_((BYTE*)s.record_.UserData + s.record_.UserDataLength)
     , pBufferIndex_((BYTE*)s.record_.UserData)
     , lastPropertyIndex_(0)
+    , pPropertyNames_(s.pPropertyNames_)
+    , propertyCache_(s.pSchema_->PropertyCount)
     {}
 
     inline property_iterator parser::properties() const
@@ -129,15 +132,40 @@ namespace krabs {
         // the contents within it. This is janky, so our strategy is to
         // minimize this as much as possible via caching.
 
-        // The first step is to use our cache for the property to see if we've
-        // discovered it already.
-        for (auto &item : propertyCache_) {
-            if (name == item.first) {
-                return item.second;
+        const ULONG totalPropCount = schema_.pSchema_->PropertyCount;
+
+        // Resolve property name to index.
+        ULONG index = totalPropCount; // sentinel = not found
+        if (pPropertyNames_) {
+            // Fast path: use the persistent name to index map shared across
+            // all events of the same type.
+            auto it = pPropertyNames_->find(std::wstring_view(name));
+            if (it != pPropertyNames_->end()) {
+                index = it->second;
+            }
+        } else {
+            // Fallback: linear scan of property names in the schema.
+            for (ULONG i = 0; i < totalPropCount; ++i) {
+                auto &propInfo = schema_.pSchema_->EventPropertyInfoArray[i];
+                const wchar_t *pName = reinterpret_cast<const wchar_t*>(
+                    reinterpret_cast<const BYTE*>(schema_.pSchema_) +
+                    propInfo.NameOffset);
+                if (name == pName) {
+                    index = i;
+                    break;
+                }
             }
         }
 
-        const ULONG totalPropCount = schema_.pSchema_->PropertyCount;
+        if (index >= totalPropCount) {
+            return property_info();
+        }
+
+        // The first step is to use our cache for the property to see if we've
+        // discovered it already.
+        if (index < lastPropertyIndex_) {
+            return propertyCache_[index];
+        }
 
         assert((pBufferIndex_ <= pEndBuffer_ && pBufferIndex_ >= schema_.record_.UserData) &&
                "invariant: we should've already thrown for falling off the edge");
@@ -153,16 +181,13 @@ namespace krabs {
         // to find it. While we're going through the blob to find it, we'll
         // remember what we've seen to save time later.
         //
-        // Question: Why don't we just populate the cache before looking up any
-        //           properties and simplify our code (less state, etc)?
-        //
-        // Answer:   Doing that introduces overhead in the case that only a
-        //           subset of properties are needed. While this code is a bit
-        //           more complicated, we introduce no additional performance
-        //           overhead at runtime.
-        for (auto &i = lastPropertyIndex_; i < totalPropCount; ++i) {
+        // Note: The name-to-index map is built once per schema type (cheap
+        // metadata scan). But the blob walk below is lazy per-event -- we
+        // only walk forward to the requested index, avoiding overhead when
+        // only a subset of properties are needed.
+        while (lastPropertyIndex_ <= index) {
 
-            auto &currentPropInfo = schema_.pSchema_->EventPropertyInfoArray[i];
+            auto &currentPropInfo = schema_.pSchema_->EventPropertyInfoArray[lastPropertyIndex_];
             const wchar_t *pName = reinterpret_cast<const wchar_t*>(
                                         reinterpret_cast<const BYTE*>(schema_.pSchema_) +
                                         currentPropInfo.NameOffset);
@@ -179,26 +204,19 @@ namespace krabs {
             }
 
             property_info propInfo(pBufferIndex_, currentPropInfo, propertyLength);
-            cache_property(pName, propInfo);
+            cache_property(lastPropertyIndex_, propInfo);
 
             // advance the buffer index since we've already processed this property
             pBufferIndex_ += propertyLength;
-
-            // The property was found, return it
-            if (name == pName) {
-                // advance the index since we've already processed this property
-                ++i;
-                return propInfo;
-            }
+            lastPropertyIndex_++;
         }
 
-        // property wasn't found, return an empty propInfo
-        return property_info();
+        return propertyCache_[index];
     }
 
-    inline void parser::cache_property(const wchar_t *name, property_info propInfo)
+    inline void parser::cache_property(ULONG index, property_info info)
     {
-        propertyCache_.push_front(std::make_pair(name, propInfo));
+        propertyCache_[index] = info;
     }
 
     inline void throw_if_property_not_found(const property_info &propInfo)

--- a/krabs/krabs/schema.hpp
+++ b/krabs/krabs/schema.hpp
@@ -308,6 +308,8 @@ namespace krabs {
     private:
         const EVENT_RECORD &record_;
         const TRACE_EVENT_INFO *pSchema_;
+        // Persistent name to index map, owned by schema_locator. May be nullptr.
+        const property_name_map *pPropertyNames_;
 
     private:
         friend std::wstring event_name(const schema &);
@@ -337,11 +339,13 @@ namespace krabs {
     inline schema::schema(const EVENT_RECORD &record, const krabs::schema_locator &schema_locator)
         : record_(record)
         , pSchema_(schema_locator.get_event_schema(record))
+        , pPropertyNames_(schema_locator.get_property_names(pSchema_))
     { }
 
     inline schema::schema(const EVENT_RECORD &record, const PTRACE_EVENT_INFO pSchema)
         : record_(record)
         , pSchema_(pSchema)
+        , pPropertyNames_(nullptr)
     { }
 
     inline bool schema::operator==(const schema &other) const

--- a/krabs/krabs/schema_locator.hpp
+++ b/krabs/krabs/schema_locator.hpp
@@ -14,6 +14,7 @@
 #include <evntrace.h>
 
 #include <memory>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 #include <cassert>
@@ -174,6 +175,14 @@ namespace krabs {
 
     /**
      * <summary>
+     * Maps property names to their index in the schema.
+     * Keys are wstring_views pointing into stable TRACE_EVENT_INFO memory.
+     * </summary>
+     */
+    using property_name_map = std::unordered_map<std::wstring_view, ULONG>;
+
+    /**
+     * <summary>
      * Fetches and caches schemas from TDH.
      * NOTE: this cache also reduces the number of managed to native transitions
      * when krabs is compiled into a managed assembly.
@@ -206,8 +215,21 @@ namespace krabs {
          */
         bool has_event_schema(const EVENT_RECORD& record) const;
 
+        /**
+         * <summary>
+         * Returns the persistent property name to index map for a schema.
+         * The map is built when the schema is first cached.
+         * Returns nullptr if pSchema is null or not in the cache.
+         * </summary>
+         */
+        const property_name_map* get_property_names(const TRACE_EVENT_INFO* pSchema) const;
+
     private:
+        void build_property_names(const TRACE_EVENT_INFO* pSchema) const;
+
         mutable std::unordered_map<schema_key, std::variant<std::unique_ptr<char[]>, TDHSTATUS>> cache_;
+        // Persistent property name to index maps, keyed by schema pointer.
+        mutable std::unordered_map<const TRACE_EVENT_INFO*, property_name_map> property_name_cache_;
     };
 
     // Implementation
@@ -310,9 +332,10 @@ namespace krabs {
 
         // Add the new instance to the cache.
         // NB: key's 'internalize_name' gets called by the cctor here.
-        if (status == ERROR_SUCCESS)
+        if (status == ERROR_SUCCESS) {
             cache_.emplace(key, std::move(buffer));
-        else
+            build_property_names(returnVal);
+        } else
             cache_.emplace(key, status);
 
         return returnVal;
@@ -323,6 +346,29 @@ namespace krabs {
         TDHSTATUS status = ERROR_SUCCESS;
         get_event_schema_no_throw(record, status);
         return status == ERROR_SUCCESS;
+    }
+
+    inline void schema_locator::build_property_names(const TRACE_EVENT_INFO* pSchema) const
+    {
+        property_name_map names;
+        for (ULONG i = 0; i < pSchema->PropertyCount; ++i) {
+            const wchar_t* pName = reinterpret_cast<const wchar_t*>(
+                reinterpret_cast<const BYTE*>(pSchema) +
+                pSchema->EventPropertyInfoArray[i].NameOffset);
+            names.emplace(std::wstring_view(pName), i);
+        }
+        property_name_cache_.emplace(pSchema, std::move(names));
+    }
+
+    inline const property_name_map* schema_locator::get_property_names(const TRACE_EVENT_INFO* pSchema) const
+    {
+        if (!pSchema) return nullptr;
+
+        auto it = property_name_cache_.find(pSchema);
+        if (it != property_name_cache_.end()) {
+            return &it->second;
+        }
+        return nullptr;
     }
 
     inline std::unique_ptr<char[]> get_event_schema_from_tdh(const EVENT_RECORD &record)

--- a/krabs/krabs/tdh_helpers.hpp
+++ b/krabs/krabs/tdh_helpers.hpp
@@ -7,6 +7,7 @@
 
 #include <tdh.h>
 #include <string>
+#include <string_view>
 #include <stdexcept>
 
 #include "compiler_check.hpp"
@@ -74,7 +75,7 @@ namespace krabs {
         // type that does not have any assignment validation. This compiles
         // to a no-op in release.
         template <typename T>
-        inline void assert_valid_assignment(const std::wstring&, const property_info&)
+        inline void assert_valid_assignment(std::wstring_view, const property_info&)
         {
 #ifndef NDEBUG
 
@@ -93,7 +94,7 @@ namespace krabs {
         // will fall back to the unspecialized version which is a no-op in release.
 
         inline void throw_if_invalid(
-            const std::wstring& name,
+            std::wstring_view name,
             const property_info& info,
             _TDH_IN_TYPE requested)
         {
@@ -120,7 +121,7 @@ namespace krabs {
 #define BUILD_ASSERT(type, tdh_type) \
         template <> \
         inline void assert_valid_assignment<type>(               \
-            const std::wstring& name, const property_info& info) \
+            std::wstring_view name, const property_info& info) \
         {                                                        \
             throw_if_invalid(name, info, tdh_type);              \
         }
@@ -159,7 +160,7 @@ namespace krabs {
 
         template <>
         inline void assert_valid_assignment<ip_address>(
-            const std::wstring&, const property_info& info)
+            std::wstring_view, const property_info& info)
         {
             auto outType = info.pEventPropertyInfo_->nonStructType.OutType;
 
@@ -172,7 +173,7 @@ namespace krabs {
 
         template <>
         inline void assert_valid_assignment<socket_address>(
-            const std::wstring&, const property_info& info)
+            std::wstring_view, const property_info& info)
         {
             auto outType = info.pEventPropertyInfo_->nonStructType.OutType;
 
@@ -184,7 +185,7 @@ namespace krabs {
 
         template <>
         inline void assert_valid_assignment<sid>(
-            const std::wstring&, const property_info& info)
+            std::wstring_view, const property_info& info)
         {
             auto inType = info.pEventPropertyInfo_->nonStructType.InType;
 
@@ -196,7 +197,7 @@ namespace krabs {
 
         template <>
         inline void assert_valid_assignment<pointer>(
-            const std::wstring&, const property_info& info)
+            std::wstring_view, const property_info& info)
         {
             auto inType = info.pEventPropertyInfo_->nonStructType.InType;
 
@@ -208,7 +209,7 @@ namespace krabs {
 
         template <>
         inline void assert_valid_assignment<bool>(
-            const std::wstring&, const property_info& info)
+            std::wstring_view, const property_info& info)
         {
             auto inType = info.pEventPropertyInfo_->nonStructType.InType;
 

--- a/krabsetw.nuspec
+++ b/krabsetw.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Microsoft.O365.Security.Krabsetw</id>
-        <version>4.4.7</version>
+        <version>4.4.8</version>
         <title>Krabs ETW Wrappers</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -12,8 +12,9 @@
         <description>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</description>
         <summary>Krabs ETW provides a modern C++ wrapper around the low-level ETW trace consumption functions</summary>
         <releaseNotes>
-            Version 4.4.7:
-              - Add process_start_key() to read ProcessStartKey from extended data
+            Version 4.4.8:
+              - Optimize parser property lookup with persistent name-to-index map
+              - Use std::wstring_view for parser property name parameters
         </releaseNotes>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <language />


### PR DESCRIPTION
I'm writing a modern Rust ETW parsing library, and was doing some parsing benchmarking.

I was surprised at just how more performant my approach was againt existing approaches so I did a little digging.

The main issue for krabs seemed to be a linear scan over a per-event property cache. This is effectively an O(N<sup>2</sup>) scan if you grab all properties - and the cache actually only hits if you grab the same property twice. 😱 

Plus wstring temporaries.

| Event Type | krabsetw 4.4.8 | krabsetw 4.4.6 | ferrisetw 1.2.0 | TdhFormatProperty | TdhFormatProperty (naive) | TdhGetProperty |
|--|--:|--:|--:|--:|--:|--:|
| **Process Start** (16 fields) | 1286 ns | 2522 ns | 2503 ns | 541 ns | 1218 ns | 3684 ns |
| **RPC Client Call** (9 fields) | 516 ns | 771 ns | 1213 ns | 338 ns | 481 ns | 1755 ns |
| **Registry CreateKey** (6 fields) | 331 ns | 467 ns | 749 ns | 548 ns | 700 ns | 1577 ns |
| **File Create** (7 fields) | 410 ns | 872 ns | 867 ns | 294 ns | 489 ns | 1146 ns |
| **Thread Start** (10 fields) | 485 ns | 1055 ns | 905 ns | 201 ns | 849 ns | 1482 ns |

- All measurements are per-event averages (ns) over the same captured set of events run on my laptop.

